### PR TITLE
fix: Fix building locally on Windows

### DIFF
--- a/packages/tosu/package.json
+++ b/packages/tosu/package.json
@@ -8,9 +8,10 @@
         "ts:run": "cross-env NODE_ENV=development ts-node --transpile-only -r tsconfig-paths/register --project tsconfig.json",
         "ts:compile": "ncc build src/index.ts -o dist -m -d",
         "run:dev": "pnpm run genver && pnpm run ts:run src/index.ts",
-        "compile:prepare-htmls": "cp -rf node_modules/@tosu/server/assets ./dist",
-        "compile:win": "pnpm run genver && pnpm run ts:compile && pnpm run compile:prepare-htmls && pkg --output dist/tosu.exe --debug --config pkg.win.json --compress brotli dist/index.js && pnpm run ts:run src/postBuild.ts",
-        "compile:linux": "pnpm run genver && pnpm run ts:compile && pnpm run compile:prepare-htmls && pkg --output dist/tosu --debug --config pkg.linux.json --compress brotli dist/index.js"
+        "compile:prepare-htmls-win": "xcopy node_modules\\@tosu\\server\\assets .\\dist\\assets\\ /E /Y /Q",
+        "compile:prepare-htmls-linux": "cp -rf node_modules/@tosu/server/assets ./dist",
+        "compile:win": "pnpm run genver && pnpm run ts:compile && pnpm run compile:prepare-htmls-win && pkg --output dist/tosu.exe --debug --config pkg.win.json --compress brotli dist/index.js && pnpm run ts:run src/postBuild.ts",
+        "compile:linux": "pnpm run genver && pnpm run ts:compile && pnpm run compile:prepare-htmls-linux && pkg --output dist/tosu --debug --config pkg.linux.json --compress brotli dist/index.js"
     },
     "dependencies": {
         "@tosu/common": "workspace:*",


### PR DESCRIPTION
When trying to build tosu locally on Windows (as specified in https://github.com/tosuapp/tosu/blob/master/DEVELOPMENT.md), the process will throw an error when copying the `assets` folder, as there is no `cp` command on Windows.

Trying to compile `master` (https://github.com/tosuapp/tosu/commit/ebf1f2e78faeda04c186247ef6fd1d0f5aa47ad2) locally on Windows:
![image](https://github.com/user-attachments/assets/43408bf6-cf10-4bd0-978d-dcb837717c71)

This PR splits the `prepare-htmls` package script into two platform-specific ones.