### PR TITLE
Fix: tosu throwing `ENOENT` errors on paths with trailing spaces inside.

### DIFF
--- a/packages/tosu/src/states/beatmap.ts
+++ b/packages/tosu/src/states/beatmap.ts
@@ -340,9 +340,9 @@ export class BeatmapPP extends AbstractState {
             }
 
             const mapPath = path.join(
-                global.songsFolder,
-                menu.folder,
-                menu.filename
+                global.songsFolder.trim(),
+                menu.folder.trim(),
+                menu.filename.trim()
             );
 
             try {


### PR DESCRIPTION
Related https://discord.com/channels/1056534107330445362/1334211010390655016