### PR TITLE
Fix: Ensure `utf-8` encoding & path cleanup.

### DIFF
--- a/packages/tosu/src/instances/index.ts
+++ b/packages/tosu/src/instances/index.ts
@@ -18,6 +18,7 @@ import { ResultScreen } from '@/states/resultScreen';
 import { Settings } from '@/states/settings';
 import { TourneyManager } from '@/states/tourney';
 import { User } from '@/states/user';
+import { cleanPath } from '@/utils/converters';
 
 export interface DataRepoList {
     settings: Settings;
@@ -63,7 +64,7 @@ export abstract class AbstractInstance {
         this.pid = pid;
 
         this.process = new Process(this.pid, bitness);
-        this.path = this.process.path;
+        this.path = cleanPath(this.process.path);
         this.bitness = bitness;
 
         this.client =

--- a/packages/tosu/src/instances/lazerInstance.ts
+++ b/packages/tosu/src/instances/lazerInstance.ts
@@ -10,7 +10,6 @@ import {
 import { LazerMemory } from '@/memory/lazer';
 import { Gameplay } from '@/states/gameplay';
 import { Global } from '@/states/global';
-import { cleanPath } from '@/utils/converters';
 
 import { AbstractInstance } from '.';
 
@@ -59,7 +58,7 @@ export class LazerInstance extends AbstractInstance {
 
                 if (!global.gameFolder) {
                     global.setGameFolder(this.path);
-                    global.setSongsFolder(cleanPath(global.memorySongsFolder));
+                    global.setSongsFolder(global.memorySongsFolder);
                 }
 
                 // update important data before doing rest

--- a/packages/tosu/src/instances/lazerInstance.ts
+++ b/packages/tosu/src/instances/lazerInstance.ts
@@ -10,6 +10,7 @@ import {
 import { LazerMemory } from '@/memory/lazer';
 import { Gameplay } from '@/states/gameplay';
 import { Global } from '@/states/global';
+import { cleanPath } from '@/utils/converters';
 
 import { AbstractInstance } from '.';
 
@@ -58,7 +59,7 @@ export class LazerInstance extends AbstractInstance {
 
                 if (!global.gameFolder) {
                     global.setGameFolder(this.path);
-                    global.setSongsFolder(global.memorySongsFolder);
+                    global.setSongsFolder(cleanPath(global.memorySongsFolder));
                 }
 
                 // update important data before doing rest

--- a/packages/tosu/src/instances/osuInstance.ts
+++ b/packages/tosu/src/instances/osuInstance.ts
@@ -61,13 +61,11 @@ export class OsuInstance extends AbstractInstance {
                 }
 
                 if (!global.gameFolder) {
-                    global.setGameFolder(cleanPath(this.path));
+                    global.setGameFolder(this.path);
 
                     // condition when user have different BeatmapDirectory in osu! config
-                    if (fs.existsSync(cleanPath(global.memorySongsFolder))) {
-                        global.setSongsFolder(
-                            cleanPath(global.memorySongsFolder)
-                        );
+                    if (fs.existsSync(global.memorySongsFolder)) {
+                        global.setSongsFolder(global.memorySongsFolder);
                     } else {
                         global.setSongsFolder(
                             cleanPath(this.path, global.memorySongsFolder)

--- a/packages/tosu/src/instances/osuInstance.ts
+++ b/packages/tosu/src/instances/osuInstance.ts
@@ -7,12 +7,12 @@ import {
     wLogger
 } from '@tosu/common';
 import fs from 'fs';
-import path from 'path';
 
 import { AbstractInstance } from '@/instances/index';
 import { StableMemory } from '@/memory/stable';
 import { Gameplay } from '@/states/gameplay';
 import { Global } from '@/states/global';
+import { cleanPath } from '@/utils/converters';
 
 export class OsuInstance extends AbstractInstance {
     gameOverlayAllowed = true;
@@ -61,14 +61,16 @@ export class OsuInstance extends AbstractInstance {
                 }
 
                 if (!global.gameFolder) {
-                    global.setGameFolder(this.path);
+                    global.setGameFolder(cleanPath(this.path));
 
                     // condition when user have different BeatmapDirectory in osu! config
-                    if (fs.existsSync(global.memorySongsFolder)) {
-                        global.setSongsFolder(global.memorySongsFolder);
+                    if (fs.existsSync(cleanPath(global.memorySongsFolder))) {
+                        global.setSongsFolder(
+                            cleanPath(global.memorySongsFolder)
+                        );
                     } else {
                         global.setSongsFolder(
-                            path.join(this.path, global.memorySongsFolder)
+                            cleanPath(this.path, global.memorySongsFolder)
                         );
                     }
                 }

--- a/packages/tosu/src/states/beatmap.ts
+++ b/packages/tosu/src/states/beatmap.ts
@@ -466,12 +466,13 @@ export class BeatmapPP extends AbstractState {
                 const { bpm, bpmMin, bpmMax } = this.lazerBeatmap;
 
                 if (
-                    this.lazerBeatmap.events.backgroundPath !==
+                    cleanPath(this.lazerBeatmap.events.backgroundPath || '') !==
                         menu.backgroundFilename &&
                     !lazerByPass
                 ) {
-                    menu.backgroundFilename =
-                        this.lazerBeatmap.events.backgroundPath || '';
+                    menu.backgroundFilename = cleanPath(
+                        this.lazerBeatmap.events.backgroundPath || ''
+                    );
                 }
 
                 this.previewtime = this.lazerBeatmap.general.previewTime;

--- a/packages/tosu/src/states/beatmap.ts
+++ b/packages/tosu/src/states/beatmap.ts
@@ -315,9 +315,9 @@ export class BeatmapPP extends AbstractState {
                     `beatmapPP updateMapMetadata`,
                     `Skip osu! music theme file`,
                     {
-                        SongsFolder: cleanPath(global.songsFolder),
-                        Folder: cleanPath(menu.folder),
-                        Path: cleanPath(menu.filename)
+                        SongsFolder: global.songsFolder,
+                        Folder: menu.folder,
+                        Path: menu.filename
                     }
                 );
                 return;
@@ -330,9 +330,9 @@ export class BeatmapPP extends AbstractState {
                     `beatmapPP updateMapMetadata`,
                     `Skip new map creation`,
                     {
-                        SongsFolder: cleanPath(global.songsFolder),
-                        Folder: cleanPath(menu.folder),
-                        Path: cleanPath(menu.filename)
+                        SongsFolder: global.songsFolder,
+                        Folder: menu.folder,
+                        Path: menu.filename
                     }
                 );
                 return;

--- a/packages/tosu/src/states/beatmap.ts
+++ b/packages/tosu/src/states/beatmap.ts
@@ -3,12 +3,11 @@ import { ClientType, config, wLogger } from '@tosu/common';
 import fs from 'fs';
 import { Beatmap as ParsedBeatmap, TimingPoint } from 'osu-classes';
 import { BeatmapDecoder } from 'osu-parsers';
-import path from 'path';
 
 import { BeatmapStrains } from '@/api/types/v1';
 import { AbstractInstance } from '@/instances';
 import { AbstractState } from '@/states';
-import { fixDecimals } from '@/utils/converters';
+import { cleanPath, fixDecimals } from '@/utils/converters';
 import { removeDebuffMods } from '@/utils/osuMods';
 import { CalculateMods, ModsLazer } from '@/utils/osuMods.types';
 
@@ -316,9 +315,9 @@ export class BeatmapPP extends AbstractState {
                     `beatmapPP updateMapMetadata`,
                     `Skip osu! music theme file`,
                     {
-                        SongsFolder: global.songsFolder,
-                        Folder: menu.folder,
-                        Path: menu.filename
+                        SongsFolder: cleanPath(global.songsFolder),
+                        Folder: cleanPath(menu.folder),
+                        Path: cleanPath(menu.filename)
                     }
                 );
                 return;
@@ -331,18 +330,18 @@ export class BeatmapPP extends AbstractState {
                     `beatmapPP updateMapMetadata`,
                     `Skip new map creation`,
                     {
-                        SongsFolder: global.songsFolder,
-                        Folder: menu.folder,
-                        Path: menu.filename
+                        SongsFolder: cleanPath(global.songsFolder),
+                        Folder: cleanPath(menu.folder),
+                        Path: cleanPath(menu.filename)
                     }
                 );
                 return;
             }
 
-            const mapPath = path.join(
-                global.songsFolder.trim(),
-                menu.folder.trim(),
-                menu.filename.trim()
+            const mapPath = cleanPath(
+                global.songsFolder,
+                menu.folder,
+                menu.filename
             );
 
             try {

--- a/packages/tosu/src/states/global.ts
+++ b/packages/tosu/src/states/global.ts
@@ -1,6 +1,7 @@
 import { ClientType, wLogger } from '@tosu/common';
 
 import { AbstractState } from '@/states';
+import { cleanPath } from '@/utils/converters';
 import { defaultCalculatedMods } from '@/utils/osuMods';
 import { CalculateMods } from '@/utils/osuMods.types';
 
@@ -60,8 +61,8 @@ export class Global extends AbstractState {
             this.gameTime = result.gameTime;
             this.menuMods = result.menuMods;
 
-            this.skinFolder = result.skinFolder;
-            this.memorySongsFolder = result.memorySongsFolder;
+            this.skinFolder = cleanPath(result.skinFolder);
+            this.memorySongsFolder = cleanPath(result.memorySongsFolder);
 
             this.resetReportCount('global updateState');
         } catch (exc) {

--- a/packages/tosu/src/states/menu.ts
+++ b/packages/tosu/src/states/menu.ts
@@ -1,6 +1,7 @@
 import { ClientType, wLogger } from '@tosu/common';
 
 import { AbstractState } from '@/states';
+import { cleanPath } from '@/utils/converters';
 
 export class Menu extends AbstractState {
     gamemode: number;
@@ -75,7 +76,7 @@ export class Menu extends AbstractState {
 
             // MD5 hasn't changed in over NEW_MAP_COMMIT_DELAY, commit to new map
             this.checksum = result.checksum;
-            this.filename = result.filename;
+            this.filename = cleanPath(result.filename);
 
             this.plays = result.plays;
             this.artist = result.artist;
@@ -87,9 +88,9 @@ export class Menu extends AbstractState {
             this.cs = result.cs;
             this.hp = result.hp;
             this.od = result.od;
-            this.audioFilename = result.audioFilename;
-            this.backgroundFilename = result.backgroundFilename;
-            this.folder = result.folder;
+            this.audioFilename = cleanPath(result.audioFilename);
+            this.backgroundFilename = cleanPath(result.backgroundFilename);
+            this.folder = cleanPath(result.folder);
             this.creator = result.creator;
             this.difficulty = result.difficulty;
             this.mapID = result.mapID;

--- a/packages/tosu/src/utils/converters.ts
+++ b/packages/tosu/src/utils/converters.ts
@@ -87,7 +87,7 @@ export const cleanPath = (...paths: string[]): string => {
     paths = paths.map((path) =>
         Buffer.from(path.trim())
             .toString('utf8')
-            .replace(/[<>:"|?*]/g, '')
+            .replace(process.platform === 'win32' ? /[<>:"|?*]/g : /\//g, '')
     );
 
     return paths.join(...paths);

--- a/packages/tosu/src/utils/converters.ts
+++ b/packages/tosu/src/utils/converters.ts
@@ -84,7 +84,7 @@ export const numberFromDecimal = (
  * @returns {string} Joined path
  */
 export const cleanPath = (...paths: string[]): string => {
-    paths.map((path) =>
+    paths = paths.map((path) =>
         Buffer.from(path.trim())
             .toString('utf8')
             .replace(/[<>:"|?*]/g, '')

--- a/packages/tosu/src/utils/converters.ts
+++ b/packages/tosu/src/utils/converters.ts
@@ -76,3 +76,19 @@ export const numberFromDecimal = (
 
     return value;
 };
+
+/**
+ * Joins multiple paths into a single path, replacing invalid Windows path characters in the process
+ *
+ * @param {...string[]} paths Paths to join
+ * @returns {string} Joined path
+ */
+export const cleanPath = (...paths: string[]): string => {
+    paths.map((path) =>
+        Buffer.from(path.trim())
+            .toString('utf8')
+            .replace(/[<>:"|?*]/g, '')
+    );
+
+    return paths.join(...paths);
+};

--- a/packages/tosu/src/utils/converters.ts
+++ b/packages/tosu/src/utils/converters.ts
@@ -78,7 +78,7 @@ export const numberFromDecimal = (
 };
 
 /**
- * Joins multiple paths into a single path, replacing invalid Windows path characters in the process
+ * Joins multiple paths into a single path, replacing invalid path characters in the process.
  *
  * @param {...string[]} paths Paths to join
  * @returns {string} Joined path


### PR DESCRIPTION
The function `cleanPath` sanitizes the paths passed, removing special chars (that would never be in a path, unless incorrect readout), trimming trailling spaces (similar to #290 ) and using utf-8 as encoding (hopefully fixing [this issue](https://discord.com/channels/1056534107330445362/1334946353096425566))