### PR TITLE
fix: Loosen `node20`'s OpenSSL default TLS handshake restrictions.

### DIFF
--- a/packages/common/utils/downloader.ts
+++ b/packages/common/utils/downloader.ts
@@ -49,7 +49,10 @@ export const downloadFile = (
             headers: {
                 Accept: 'application/octet-stream',
                 'User-Agent': '@tosuapp/tosu'
-            }
+            },
+            agent: new https.Agent({
+                secureOptions: require('node:crypto').constants.SSL_OP_ALL
+            })
         };
 
         // find url


### PR DESCRIPTION
Tries to fix `EPROTO ssl3 error "wrong version number"`
Has not been tested as I do not encounter the issue but I believe the issue only appears for people who use the bundled nodejs package.

![image](https://github.com/user-attachments/assets/cfd09881-2a9d-4dfc-bf5b-0e6ebfbdb0b7)