### PR TITLE
feat: Disallow tosu startup under OneDrive default directories.

### DIFF
--- a/packages/tosu/src/index.ts
+++ b/packages/tosu/src/index.ts
@@ -1,6 +1,8 @@
 import { argumetsParser, config, wLogger, watchConfigFile } from '@tosu/common';
 import { Server } from '@tosu/server';
 import { autoUpdater, checkUpdates } from '@tosu/updater';
+import { homedir } from 'node:os';
+import { resolve } from 'path';
 import { Process } from 'tsprocess/dist/process';
 
 import { InstanceManager } from '@/instances/manager';
@@ -37,9 +39,34 @@ const currentVersion = require(process.cwd() + '/_version.js');
         }
     }
 
-    wLogger.info('Searching for osu!');
+    let isInOneDrive = false;
+    if (process.platform === 'win32') {
+        const currentPath = resolve().toLowerCase();
+        const homeDir = homedir().toLowerCase();
 
-    httpServer.start();
-    instanceManager.runWatcher();
-    instanceManager.runDetemination();
+        // NOTE: The listed strings are only the default OneDrive paths.
+        const oneDrivePaths = [
+            'OneDrive',
+            'OneDrive - Personal',
+            'OneDrive - Business',
+            'OneDrive for Business'
+        ].map((path) => resolve(homeDir, path).toLowerCase());
+
+        isInOneDrive = oneDrivePaths.some((path) =>
+            currentPath.startsWith(path)
+        );
+    }
+
+    if (isInOneDrive === false) {
+        wLogger.info('Searching for osu!');
+
+        httpServer.start();
+        instanceManager.runWatcher();
+        instanceManager.runDetemination();
+    } else {
+        wLogger.warn(
+            'tosu cannot run from a OneDrive folder due to potential sync conflicts and performance issues.'
+        );
+        wLogger.warn('Please move the application to a local folder');
+    }
 })();


### PR DESCRIPTION
Became a common issue...

The only issue here is that OneDrive users can change the path to whatever they desire, so... this only checks default OneDrive directories. But I guess it's a good addition no matter what.

![image](https://github.com/user-attachments/assets/14c0671a-9b35-44d4-8928-491a225f6734)
