### PR TITLE
fix realtime pp calc for the standard ruleset in lazer

### DIFF
--- a/packages/tosu/src/memory/lazer.ts
+++ b/packages/tosu/src/memory/lazer.ts
@@ -817,8 +817,8 @@ export class LazerMemory extends AbstractMemory<LazerPatternData> {
             hit50: statistics.meh,
             hitMiss: statistics.miss,
             sliderEndHits: statistics.sliderTailHit,
-            smallTickHits: statistics.largeTickHit,
-            largeTickHits: statistics.smallTickHit,
+            smallTickHits: statistics.smallTickHit,
+            largeTickHits: statistics.largeTickHit,
             combo,
             maxCombo: this.process.readInt(scoreInfo + 0xc4)
         };


### PR DESCRIPTION
Noticed this a while ago, but didn't give it a serious thought until I added the lazer's built-in pp component on the screen and saw the big difference. The deviation is linear, the longer the map, the bigger the offset.

Talked to Cherry about it, apparently it was just a misassignment.

### master

https://github.com/user-attachments/assets/3c60790e-7b4a-4bd3-b76f-3e27c0c77f88

### this pr

https://github.com/user-attachments/assets/2cbe885f-f9ea-47a6-9cba-fb73088a9ca4

