### PR TITLE
Fix: Temporary skip mania pp calculation outside gameplay state

### DIFF
--- a/packages/tosu/src/states/beatmap.ts
+++ b/packages/tosu/src/states/beatmap.ts
@@ -428,6 +428,14 @@ export class BeatmapPP extends AbstractState {
                 for (const acc of [
                     100, 99, 98, 97, 96, 95, 94, 93, 92, 91, 90
                 ]) {
+                    if (
+                        this.beatmap.mode === 3 &&
+                        this.game.client === ClientType.lazer
+                    ) {
+                        ppAcc[acc] = 0.0;
+                        continue;
+                    }
+
                     const calculate = new rosu.Performance({
                         mods: removeDebuffMods(currentMods.array),
                         accuracy: acc,


### PR DESCRIPTION
Skips calculating mania beatmap pp while outside of gameplay which temporary solves the data freezing issues. (Only happening on lazer afaik)

> the cause is mania hitresult generation when only acc is given, its basically bruteforcing them until it finds the best possible one which is pretty slow