### PR TITLE
feat: Implement `maxAchievable`.

### DIFF
--- a/packages/tosu/src/api/types/v1.ts
+++ b/packages/tosu/src/api/types/v1.ts
@@ -96,7 +96,7 @@ interface PP {
 interface GameplayPP {
     current: number;
     fc: number;
-    maxThisPlay: number;
+    maxAchieved: number;
 }
 
 export interface LeaderboardPlayer {

--- a/packages/tosu/src/api/types/v1.ts
+++ b/packages/tosu/src/api/types/v1.ts
@@ -96,7 +96,7 @@ interface PP {
 interface GameplayPP {
     current: number;
     fc: number;
-    maxAchieved: number;
+    maxThisPlay: number;
 }
 
 export interface LeaderboardPlayer {

--- a/packages/tosu/src/api/types/v2.ts
+++ b/packages/tosu/src/api/types/v2.ts
@@ -241,7 +241,8 @@ export interface Rank {
 export interface Pp {
     current: number;
     fc: number;
-    maxAchievedThisPlay: number;
+    maxAchieved: number;
+    maxAchievable: number;
     detailed: detailedPp;
 }
 

--- a/packages/tosu/src/api/utils/buildResult.ts
+++ b/packages/tosu/src/api/utils/buildResult.ts
@@ -196,7 +196,7 @@ export const buildResult = (instanceManager: InstanceManager): ApiAnswer => {
             pp: {
                 current: fixDecimals(beatmapPP.currAttributes.pp),
                 fc: fixDecimals(beatmapPP.currAttributes.fcPP),
-                maxAchieved: fixDecimals(beatmapPP.currAttributes.maxAchieved)
+                maxThisPlay: fixDecimals(beatmapPP.currAttributes.maxAchieved)
             },
             keyOverlay: {
                 k1: {

--- a/packages/tosu/src/api/utils/buildResult.ts
+++ b/packages/tosu/src/api/utils/buildResult.ts
@@ -196,7 +196,7 @@ export const buildResult = (instanceManager: InstanceManager): ApiAnswer => {
             pp: {
                 current: fixDecimals(beatmapPP.currAttributes.pp),
                 fc: fixDecimals(beatmapPP.currAttributes.fcPP),
-                maxThisPlay: fixDecimals(beatmapPP.currAttributes.maxAchieved)
+                maxThisPlay: fixDecimals(beatmapPP.currAttributes.maxAchievable)
             },
             keyOverlay: {
                 k1: {

--- a/packages/tosu/src/api/utils/buildResult.ts
+++ b/packages/tosu/src/api/utils/buildResult.ts
@@ -196,7 +196,7 @@ export const buildResult = (instanceManager: InstanceManager): ApiAnswer => {
             pp: {
                 current: fixDecimals(beatmapPP.currAttributes.pp),
                 fc: fixDecimals(beatmapPP.currAttributes.fcPP),
-                maxThisPlay: fixDecimals(beatmapPP.currAttributes.maxThisPlayPP)
+                maxAchieved: fixDecimals(beatmapPP.currAttributes.maxAchieved)
             },
             keyOverlay: {
                 k1: {

--- a/packages/tosu/src/api/utils/buildResultV2.ts
+++ b/packages/tosu/src/api/utils/buildResultV2.ts
@@ -829,9 +829,8 @@ function buildPlay(
         pp: {
             current: fixDecimals(beatmapPP.currAttributes.pp),
             fc: fixDecimals(beatmapPP.currAttributes.fcPP),
-            maxAchievedThisPlay: fixDecimals(
-                beatmapPP.currAttributes.maxThisPlayPP
-            ),
+            maxAchieved: fixDecimals(beatmapPP.currAttributes.maxAchieved),
+            maxAchievable: fixDecimals(beatmapPP.currAttributes.maxAchievable),
             detailed: {
                 current: {
                     aim: fixDecimals(beatmapPP.currPPAttributes.ppAim),

--- a/packages/tosu/src/api/utils/buildResultV2.ts
+++ b/packages/tosu/src/api/utils/buildResultV2.ts
@@ -531,7 +531,8 @@ const buildLazerTourneyData = (
                         pp: {
                             current: fixDecimals(client!.score!.pp || 0),
                             fc: 0,
-                            maxAchievedThisPlay: 0,
+                            maxAchieved: 0,
+                            maxAchievable: 0,
                             detailed: {
                                 current: {
                                     aim: 0,

--- a/packages/tosu/src/states/beatmap.ts
+++ b/packages/tosu/src/states/beatmap.ts
@@ -64,7 +64,8 @@ interface BeatmapPPCurrentAttributes {
     stars: number;
     pp: number;
     fcPP: number;
-    maxThisPlayPP: number;
+    maxAchieved: number;
+    maxAchievable: number;
 }
 
 interface BeatmapPPTimings {
@@ -106,7 +107,8 @@ export class BeatmapPP extends AbstractState {
     currAttributes: BeatmapPPCurrentAttributes = {
         stars: 0.0,
         pp: 0.0,
-        maxThisPlayPP: 0.0,
+        maxAchieved: 0.0,
+        maxAchievable: 0.0,
         fcPP: 0.0
     };
 
@@ -198,7 +200,8 @@ export class BeatmapPP extends AbstractState {
         this.currAttributes = {
             stars: 0.0,
             pp: 0.0,
-            maxThisPlayPP: 0.0,
+            maxAchieved: 0.0,
+            maxAchievable: 0.0,
             fcPP: 0.0
         };
         this.currPPAttributes = {
@@ -225,11 +228,12 @@ export class BeatmapPP extends AbstractState {
     }
 
     updatePPAttributes(
-        type: 'curr' | 'fc',
+        type: 'curr' | 'fc' | 'maxAchievable',
         attributes: rosu.PerformanceAttributes
     ) {
         try {
-            if (type !== 'curr' && type !== 'fc') return;
+            if (type !== 'curr' && type !== 'fc' && type !== 'maxAchievable')
+                return;
 
             this[`${type}PPAttributes`] = {
                 ppAccuracy: attributes.ppAccuracy || 0.0,
@@ -255,26 +259,28 @@ export class BeatmapPP extends AbstractState {
     }
 
     updateCurrentAttributes(stars: number, pp: number) {
+        const maxAchieved = Math.max(pp, this.currAttributes.maxAchieved);
+
         if (this.currAttributes.pp.toFixed(2) !== pp.toFixed(2)) {
             wLogger.debug(
                 ClientType[this.game.client],
                 this.game.pid,
                 `beatmapPP updateCurrentAttributes`,
-                `maxPP -> ${this.currAttributes.maxThisPlayPP.toFixed(2)} pp -> ${pp.toFixed(2)} stars -> ${stars.toFixed(2)}`
+                `maxAchieved -> ${this.currAttributes.maxAchieved.toFixed(2)} | currentPP -> ${pp.toFixed(2)} | stars -> ${stars.toFixed(2)}`
             );
         }
-        const maxThisPlayPP = Math.max(pp, this.currAttributes.maxThisPlayPP);
 
         this.currAttributes.stars = stars;
         this.currAttributes.pp = pp;
-        this.currAttributes.maxThisPlayPP = maxThisPlayPP;
+        this.currAttributes.maxAchieved = maxAchieved;
     }
 
     resetAttributes() {
         this.currAttributes = {
             stars: 0.0,
             pp: 0.0,
-            maxThisPlayPP: 0.0,
+            maxAchieved: 0.0,
+            maxAchievable: 0.0,
             fcPP: this.ppAcc[100] || 0.0
         };
 

--- a/packages/tosu/src/states/gameplay.ts
+++ b/packages/tosu/src/states/gameplay.ts
@@ -574,12 +574,21 @@ export class Gameplay extends AbstractState {
             const currPerformance = this.gradualPerformance.nth(
                 scoreParams,
                 offset - 1
-            )!;
+            );
 
             const fcPerformance = new rosu.Performance({
                 mods: removeDebuffMods(this.mods.array),
                 misses: 0,
                 accuracy: this.accuracy,
+                lazer: this.game.client === ClientType.lazer
+            }).calculate(this.performanceAttributes);
+
+            const maxAchievablePerformance = new rosu.Performance({
+                misses: this.hitMiss,
+                n50: this.hit50,
+                n100: this.hit100,
+                combo: this.maxCombo,
+                mods: removeDebuffMods(this.mods.array),
                 lazer: this.game.client === ClientType.lazer
             }).calculate(this.performanceAttributes);
             const t2 = performance.now();
@@ -596,6 +605,15 @@ export class Gameplay extends AbstractState {
             if (fcPerformance) {
                 beatmapPP.currAttributes.fcPP = fcPerformance.pp;
                 beatmapPP.updatePPAttributes('fc', fcPerformance);
+            }
+
+            if (maxAchievablePerformance) {
+                beatmapPP.currAttributes.maxAchievable =
+                    maxAchievablePerformance.pp;
+                beatmapPP.updatePPAttributes(
+                    'maxAchievable',
+                    maxAchievablePerformance
+                );
             }
 
             this.previousPassedObjects = passedObjects;

--- a/packages/tosu/src/states/gameplay.ts
+++ b/packages/tosu/src/states/gameplay.ts
@@ -35,6 +35,7 @@ export class Gameplay extends AbstractState {
     mods: CalculateMods = Object.assign({}, defaultCalculatedMods);
     hitErrors: number[];
     mode: number;
+    lostCombo: number;
     maxCombo: number;
     score: number;
     hit100: number;
@@ -84,6 +85,7 @@ export class Gameplay extends AbstractState {
 
         this.hitErrors = [];
         this.maxCombo = 0;
+        this.lostCombo = 0;
         this.score = 0;
         this.hit100 = 0;
         this.hit300 = 0;
@@ -249,11 +251,9 @@ export class Gameplay extends AbstractState {
             if (this.comboPrev > this.maxCombo) {
                 this.comboPrev = 0;
             }
-            if (
-                this.combo < this.comboPrev &&
-                this.hitMiss === this.hitMissPrev
-            ) {
-                this.hitSB += 1;
+            if (this.combo < this.comboPrev) {
+                this.lostCombo += this.comboPrev;
+                if (this.hitMiss === this.hitMissPrev) this.hitSB += 1;
             }
             this.hitMissPrev = this.hitMiss;
             this.comboPrev = this.combo;
@@ -584,10 +584,22 @@ export class Gameplay extends AbstractState {
             }).calculate(this.performanceAttributes);
 
             const maxAchievablePerformance = new rosu.Performance({
-                misses: this.hitMiss,
-                n50: this.hit50,
+                combo: Math.max(
+                    this.maxCombo,
+                    this.performanceAttributes.state?.maxCombo! - this.lostCombo
+                ),
+                n300:
+                    this.performanceAttributes.state?.maxCombo! -
+                    this.hit100 -
+                    this.hit50 -
+                    this.hitMiss,
                 n100: this.hit100,
-                combo: this.maxCombo,
+                n50: this.hit50,
+                misses: this.hitMiss,
+                smallTickHits:
+                    this.performanceAttributes.state?.osuSmallTickHits,
+                largeTickHits:
+                    this.performanceAttributes.state?.osuLargeTickHits,
                 mods: removeDebuffMods(this.mods.array),
                 lazer: this.game.client === ClientType.lazer
             }).calculate(this.performanceAttributes);


### PR DESCRIPTION
Supersedes #341 

This PR implements a new pp value called `maxAchievable` that indicates the maximum pp value a user could be getting from their play if they fc the rest of the map. This is similar to gosu's old `maxThisPlay` property, so it's a step towards gosu-tosu compatibility. (more or less...)

**Q: How is this any different from `play.pp.fc`?**
**A:** The `play.pp.fc` does not take account of misses; it shows the PP value that could have been achieved only if the player would have **never missed.** The `maxAchievable` value takes account of **all** hit judgements (300s,100s,50s & misses).

---
**!!** There's a few things to consider before merging, such as compatibility issues.
Since this PR also renames `maxAchievedThisPlay` to `maxAchieved`, there are two ways of approaching future issues:
1. Announce the future deprecation of `maxAchievedThisPlay`, but keep both values (old name and new name) even though they provide the same value. (Assuming deprecation comes later, so people have time to switch)
2. Deprecate `maxAchievedThisPlay` (announcing breaking changes) and update all counters available in the tosu counters repository with the new property name (which can be done very easily by me), but the issue still remains with the local/private pp counters that use this

> [!IMPORTANT]
> Either way, the socket will need to be updated with the new changes, which will be a future PR after this gets merged. 

--- 

> [!NOTE]
> The new value has only been tested on osu!std so far, I am not aware of the possible issues with the other rulesets. 