### PR TITLE
fix: in-game overlay returning null code.

### DIFF
--- a/packages/ingame-overlay-updater/src/index.ts
+++ b/packages/ingame-overlay-updater/src/index.ts
@@ -112,10 +112,10 @@ export const runOverlay = async () => {
                 wLogger.warn('[ingame-overlay] run error', err);
                 resolve(false);
             });
-            child.on('exit', (code) => {
+            child.on('exit', (code, signal) => {
                 if (code !== 0) {
                     wLogger.error(
-                        `[ingame-overlay] Unknown exit code: ${code}`
+                        `[ingame-overlay] Unknown exit code: ${code} ${signal ? `(${signal})` : ''}`
                     );
                     return;
                 }


### PR DESCRIPTION
Usually, when a process child returns null as exit code, it means that the process was not terminated normally (Likely terminated by a signal instead). This PR just adds the signal (if any) to the logging part. (a step to easily debug the few reports we've got so far with `unknown code: null`) 

More info about the signals [here](https://nodejs.org/api/process.html#signal-events)