### PR TITLE
feat: redirect in-game overlay logging, process status tracking

### DIFF
--- a/packages/ingame-overlay-updater/src/index.ts
+++ b/packages/ingame-overlay-updater/src/index.ts
@@ -6,7 +6,7 @@ import {
     unzip,
     wLogger
 } from '@tosu/common';
-import { execFile } from 'node:child_process';
+import { ChildProcess, spawn } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, rm } from 'node:fs/promises';
 import path from 'node:path';
@@ -16,116 +16,95 @@ const currentVersion = require(process.cwd() + '/_version.js');
 
 const platform = platformResolver(process.platform);
 
-export const runOverlay = async () => {
-    try {
-        if (process.platform !== 'win32') {
-            wLogger.error(
-                '[ingame-overlay] This feature is currently only available on the Windows platform'
-            );
-            return false;
-        }
-
-        checkGameOverlayConfig();
-
-        const gameOverlayPath = path.join(getProgramPath(), 'game-overlay');
-        if (
-            existsSync(path.join(gameOverlayPath)) &&
-            !existsSync(path.join(gameOverlayPath, 'version'))
-        ) {
-            // old overlay detected, removing it
-            wLogger.warn(
-                '[ingame-overlay] Old version of the ingame overlay detected. Removing...'
-            );
-            await rm(gameOverlayPath, { recursive: true, force: true });
-        }
-
-        if (existsSync(path.join(gameOverlayPath, 'version'))) {
-            const overlayVersion = readFileSync(
-                path.join(gameOverlayPath, 'version'),
-                'utf8'
-            );
-            if (overlayVersion.trimEnd() !== currentVersion) {
-                await rm(gameOverlayPath, { recursive: true, force: true });
-
-                wLogger.warn(
-                    '[ingame-overlay] A newer version of the ingame overlay is available. Updating...'
-                );
-            }
-        }
-
-        if (!existsSync(gameOverlayPath)) {
-            const archivePath = path.join(
-                gameOverlayPath,
-                'tosu-gameoverlay.zip'
-            );
-
-            await mkdir(gameOverlayPath, { recursive: true });
-
-            const request = await fetch(
-                `https://api.github.com/repos/tosuapp/tosu/releases/tags/v${currentVersion}`
-            );
-            const json = (await request.json()) as any;
-            const {
-                assets
-            }: {
-                assets: { name: string; browser_download_url: string }[];
-            } = json;
-
-            const findAsset = assets.find(
-                (r) =>
-                    r.name.includes('tosu-overlay') && r.name.endsWith('.zip')
-            );
-            if (!findAsset) {
-                wLogger.info(
-                    '[ingame-overlay]',
-                    `Could not find downloadable files for your operating system. (${platform.type})`
-                );
-                return;
-            }
-
-            await downloadFile(findAsset.browser_download_url, archivePath);
-
-            await unzip(archivePath, gameOverlayPath);
-            await rm(archivePath);
-
-            wLogger.info('[ingame-overlay] Ingame overlay downloaded');
-        }
-
-        wLogger.warn(`[ingame-overlay] Starting...`);
-        return new Promise((resolve) => {
-            let error = false;
-            const child = execFile(
-                path.join(gameOverlayPath, 'tosu-ingame-overlay.exe'),
-                [],
-                {
-                    cwd: gameOverlayPath,
-                    windowsHide: true
-                }
-            );
-            child.on('error', (err) => {
-                error = true;
-
-                wLogger.warn('[ingame-overlay] run error', err);
-                resolve(false);
-            });
-            child.on('exit', (code) => {
-                if (code !== 0) {
-                    wLogger.error(
-                        `[ingame-overlay] Unknown exit code: ${code}`
-                    );
-                    return;
-                }
-                if (error) return;
-
-                wLogger.warn(`[ingame-overlay] Exited...`);
-
-                resolve(true);
-            });
-        });
-    } catch (exc) {
-        wLogger.error('[ingame-overlay]', (exc as any).message);
-        wLogger.debug('[ingame-overlay]', exc);
-
-        return false;
+export async function runOverlay(): Promise<ChildProcess> {
+    if (process.platform !== 'win32') {
+        throw new Error(
+            'This feature is currently only available on the Windows platform'
+        );
     }
-};
+
+    checkGameOverlayConfig();
+
+    const gameOverlayPath = path.join(getProgramPath(), 'game-overlay');
+    if (
+        existsSync(path.join(gameOverlayPath)) &&
+        !existsSync(path.join(gameOverlayPath, 'version'))
+    ) {
+        // old overlay detected, removing it
+        wLogger.warn(
+            '[ingame-overlay] Old version of the ingame overlay detected. Removing...'
+        );
+        await rm(gameOverlayPath, { recursive: true, force: true });
+    }
+
+    if (existsSync(path.join(gameOverlayPath, 'version'))) {
+        const overlayVersion = readFileSync(
+            path.join(gameOverlayPath, 'version'),
+            'utf8'
+        );
+        if (overlayVersion.trimEnd() !== currentVersion) {
+            await rm(gameOverlayPath, { recursive: true, force: true });
+
+            wLogger.warn(
+                '[ingame-overlay] A newer version of the ingame overlay is available. Updating...'
+            );
+        }
+    }
+
+    if (!existsSync(gameOverlayPath)) {
+        const archivePath = path.join(gameOverlayPath, 'tosu-gameoverlay.zip');
+
+        await mkdir(gameOverlayPath, { recursive: true });
+
+        const request = await fetch(
+            `https://api.github.com/repos/tosuapp/tosu/releases/tags/v${currentVersion}`
+        );
+        const json = (await request.json()) as any;
+        const {
+            assets
+        }: {
+            assets: { name: string; browser_download_url: string }[];
+        } = json;
+
+        const findAsset = assets.find(
+            (r) => r.name.includes('tosu-overlay') && r.name.endsWith('.zip')
+        );
+        if (!findAsset) {
+            throw new Error(
+                `Could not find downloadable files for your operating system. (${platform.type})`
+            );
+        }
+
+        await downloadFile(findAsset.browser_download_url, archivePath);
+
+        await unzip(archivePath, gameOverlayPath);
+        await rm(archivePath);
+
+        wLogger.info('[ingame-overlay] Ingame overlay downloaded');
+    }
+
+    wLogger.warn(`[ingame-overlay] Starting...`);
+
+    const child = spawn(
+        path.join(gameOverlayPath, 'tosu-ingame-overlay.exe'),
+        [],
+        {
+            detached: false,
+            stdio: ['ignore', 'overlapped', 'overlapped'],
+            windowsHide: true,
+            shell: false
+        }
+    );
+
+    child.stdout.setEncoding('utf-8').on('data', (data: string) => {
+        // overlay logs are a bit verbose, so redirect them to debug log
+        wLogger.debug('[ingame-overlay]', data.trim());
+    });
+
+    child.stderr.setEncoding('utf-8').on('data', (data: string) => {
+        // redirect overlay error backtraces to debug error log
+        wLogger.debugError('[ingame-overlay]', data.trim());
+    });
+
+    return child;
+}

--- a/packages/ingame-overlay-updater/src/index.ts
+++ b/packages/ingame-overlay-updater/src/index.ts
@@ -92,7 +92,12 @@ export async function runOverlay(): Promise<ChildProcess> {
             detached: false,
             stdio: ['ignore', 'overlapped', 'overlapped'],
             windowsHide: true,
-            shell: false
+            shell: false,
+            env: {
+                // Force nvidia optimus to prefer dedicated gpu
+                SHIM_MCCOMPAT: '0x800000001',
+                ...process.env
+            }
         }
     );
 

--- a/packages/ingame-overlay-updater/src/index.ts
+++ b/packages/ingame-overlay-updater/src/index.ts
@@ -3,7 +3,6 @@ import {
     downloadFile,
     getProgramPath,
     platformResolver,
-    sleep,
     unzip,
     wLogger
 } from '@tosu/common';
@@ -91,9 +90,6 @@ export const runOverlay = async () => {
 
             wLogger.info('[ingame-overlay] Ingame overlay downloaded');
         }
-
-        // dum sleep to wait until all osu libraries are loaded?
-        await sleep(1000 * 3);
 
         wLogger.warn(`[ingame-overlay] Starting...`);
         return new Promise((resolve) => {

--- a/packages/ingame-overlay/main/index.ts
+++ b/packages/ingame-overlay/main/index.ts
@@ -15,6 +15,9 @@ import { OverlayManager } from './overlay/manager';
 
 async function main() {
     if (!app.requestSingleInstanceLock()) {
+        console.error(
+            'Ingame overlay is already running. Please check tray icon'
+        );
         return;
     }
 

--- a/packages/ingame-overlay/main/overlay/manager.ts
+++ b/packages/ingame-overlay/main/overlay/manager.ts
@@ -1,6 +1,5 @@
 import { promises as wql } from '@jellybrick/wql-process-monitor';
 import EventEmitter from 'node:events';
-import path from 'node:path';
 import { Process } from 'tsprocess';
 
 import { OverlayProcess } from './process';
@@ -43,8 +42,7 @@ export class OverlayManager {
         const signal = this.abortController.signal;
 
         const emitter = await wql.subscribe({
-            creation: true,
-            deletion: true
+            creation: true
         });
         emitter.on('creation', ([name, pid]) => {
             if (name === 'osu!.exe' || name === 'osulazer.exe') {
@@ -55,20 +53,6 @@ export class OverlayManager {
 
                 this.addOverlay(id);
             }
-        });
-        emitter.on('deletion', ([_, pid]) => {
-            Process.getProcessCommandLine(Number(pid)).then(
-                (cmdLine: string) => {
-                    // C:/tosu/tosu.exe -> C:/tosu -> C:/tosu/game-overlay
-                    if (
-                        path.join(cmdLine, '..', 'game-overlay') ===
-                        process.cwd()
-                    ) {
-                        // Exit overlay if tosu is closed
-                        process.exit(0);
-                    }
-                }
-            );
         });
 
         const osuProcesses = Process.findProcesses([

--- a/packages/ingame-overlay/package.json
+++ b/packages/ingame-overlay/package.json
@@ -13,7 +13,7 @@
   "author": "storycraft <storycraft@pancake.sh>",
   "dependencies": {
     "@jellybrick/wql-process-monitor": "^1.4.8",
-    "asdf-overlay-node": "^0.6.2",
+    "asdf-overlay-node": "^0.6.3",
     "tsprocess": "workspace:*"
   },
   "devDependencies": {

--- a/packages/tosu/src/instances/manager.ts
+++ b/packages/tosu/src/instances/manager.ts
@@ -145,14 +145,14 @@ export class InstanceManager {
     }
 
     async runWatcher() {
-        for (;;) {
+        while (true) {
             await this.handleProcesses();
             await setTimeout(1000);
         }
     }
 
     async runDetemination() {
-        for (;;) {
+        while (true) {
             if (!this.platformType) {
                 const platform = platformResolver(process.platform);
                 this.platformType = platform.type;

--- a/packages/tosu/src/instances/manager.ts
+++ b/packages/tosu/src/instances/manager.ts
@@ -7,6 +7,8 @@ import {
     wLogger
 } from '@tosu/common';
 import { runOverlay } from '@tosu/ingame-overlay-updater';
+import { ChildProcess } from 'node:child_process';
+import { setTimeout } from 'node:timers/promises';
 import { Process } from 'tsprocess';
 
 import { AbstractInstance } from '@/instances';
@@ -22,13 +24,10 @@ export class InstanceManager {
         [key: number]: AbstractInstance;
     };
 
-    overlayStarted: boolean = false;
+    private overlayProcess: ChildProcess | null = null;
 
     constructor() {
         this.osuInstances = {};
-
-        this.runWatcher = this.runWatcher.bind(this);
-        this.runDetemination = this.runDetemination.bind(this);
     }
 
     /**
@@ -67,7 +66,7 @@ export class InstanceManager {
         delete this.osuInstances[pid];
     }
 
-    private handleProcesses() {
+    private async handleProcesses() {
         try {
             let osuProcesses = Process.findProcesses([
                 'osu!.exe',
@@ -134,10 +133,10 @@ export class InstanceManager {
 
             if (
                 config.enableIngameOverlay &&
-                !this.overlayStarted &&
+                !this.overlayProcess &&
                 Object.keys(this.osuInstances).length > 0
             ) {
-                this.startOverlay();
+                await this.startOverlay();
             }
         } catch (exc) {
             wLogger.error('[manager]', 'handleProcesses', (exc as any).message);
@@ -145,36 +144,62 @@ export class InstanceManager {
         }
     }
 
-    runWatcher() {
-        this.handleProcesses();
-
-        setTimeout(this.runWatcher, 1000);
+    async runWatcher() {
+        for (;;) {
+            await this.handleProcesses();
+            await setTimeout(1000);
+        }
     }
 
-    runDetemination() {
-        if (!this.platformType) {
-            const platform = platformResolver(process.platform);
-            this.platformType = platform.type;
+    async runDetemination() {
+        for (;;) {
+            if (!this.platformType) {
+                const platform = platformResolver(process.platform);
+                this.platformType = platform.type;
+            }
+
+            if (this.platformType !== 'windows') return;
+
+            const focusedPID = Process.getFocusedProcess();
+            const instance = Object.values(this.osuInstances).find(
+                (r) => r.pid === focusedPID
+            );
+            if (instance) this.focusedClient = instance.client;
+
+            if (this.focusedClient === undefined) {
+                this.focusedClient =
+                    this.getInstance()?.client || ClientType.stable;
+            }
+
+            await setTimeout(100);
         }
-
-        if (this.platformType !== 'windows') return;
-
-        const focusedPID = Process.getFocusedProcess();
-        const instance = Object.values(this.osuInstances).find(
-            (r) => r.pid === focusedPID
-        );
-        if (instance) this.focusedClient = instance.client;
-
-        if (this.focusedClient === undefined) {
-            this.focusedClient =
-                this.getInstance()?.client || ClientType.stable;
-        }
-
-        setTimeout(this.runDetemination, 100);
     }
 
-    startOverlay() {
-        runOverlay();
-        this.overlayStarted = true;
+    async startOverlay() {
+        try {
+            const child = await runOverlay();
+            child.on('error', (err) => {
+                this.overlayProcess = null;
+                wLogger.warn('[ingame-overlay]', 'run error', err);
+            });
+
+            child.on('exit', (code) => {
+                this.overlayProcess = null;
+                if (code !== 0) {
+                    wLogger.error(
+                        '[ingame-overlay]',
+                        `Unknown exit code: ${code}`
+                    );
+                    return;
+                }
+
+                wLogger.warn('[ingame-overlay]', 'Exited...');
+            });
+
+            this.overlayProcess = child;
+        } catch (exc) {
+            wLogger.error('[ingame-overlay]', (exc as any).message);
+            wLogger.debug('[ingame-overlay]', exc);
+        }
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,8 +70,8 @@ importers:
         specifier: ^1.4.8
         version: 1.4.8
       asdf-overlay-node:
-        specifier: ^0.6.2
-        version: 0.6.2
+        specifier: ^0.6.3
+        version: 0.6.3
       tsprocess:
         specifier: workspace:*
         version: link:../tsprocess
@@ -1096,8 +1096,8 @@ packages:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
     engines: {node: '>=0.10.0'}
 
-  asdf-overlay-node@0.6.2:
-    resolution: {integrity: sha512-jpT9HfMbUcKi9XovsBfVAcddef5jbVFRRdjiexi/OmM8AUOtN/u313XVINbAfg7s/SnMbMTJAvaDgVOAlMGUGA==}
+  asdf-overlay-node@0.6.3:
+    resolution: {integrity: sha512-vBV7ybA2f9V8AeAJdoZSM9UQOBj6EJnOnzcOnvh3D2jEqxpGdYNtHlEh4RDIoWHqKlQFHM67ZbNe+uaUdXiqAg==}
     cpu: [x64, arm64]
     os: [win32]
 
@@ -5083,7 +5083,7 @@ snapshots:
 
   arrify@1.0.1: {}
 
-  asdf-overlay-node@0.6.2: {}
+  asdf-overlay-node@0.6.3: {}
 
   assert-plus@1.0.0:
     optional: true


### PR DESCRIPTION
* Redirect ingame overlay stdout, stderr to debug, debugError (they are verbose)
* Properly track the status of overlay process. This fix the issue tosu needs to restart completely to start ingame overlay again once the overlay is closed by user.
* close #360 pr(I included the commit before the refactor)
* add debug log when ingame overlay fail to launch due to an another instance already running(by another tosu or manual launch).
* a bit of asyncification (async `setTimeout`)
* fix ingame overlay failing due to lack of ipc access permission when osu! is launched with lower permission user than tosu
* apply start option to prefer discrete gpu