### PR TITLE
feat: Clear `logs` directory if it's size becomes significant.

### DIFF
--- a/packages/common/utils/config.ts
+++ b/packages/common/utils/config.ts
@@ -87,7 +87,7 @@ export const config = {
     timestamp: 0,
     currentVersion: '',
     updateVersion: '',
-    logsPath: ''
+    logFilePath: ''
 };
 
 export const updateConfigFile = () => {

--- a/packages/common/utils/logger.ts
+++ b/packages/common/utils/logger.ts
@@ -72,16 +72,16 @@ export const wLogger = {
 };
 
 function writeLog(type: string, ...args: any[]) {
-    if (config.logsPath === '') {
+    if (config.logFilePath === '') {
         const logsPath = path.join(getProgramPath(), 'logs');
         if (!fs.existsSync(logsPath))
             fs.mkdirSync(logsPath, { recursive: true });
 
-        config.logsPath = path.join(logsPath, `${Date.now()}.txt`);
+        config.logFilePath = path.join(logsPath, `${Date.now()}.txt`);
     }
 
     fsp.appendFile(
-        config.logsPath,
+        config.logFilePath,
         `${new Date().toISOString()} ${type} ${args.join(' ')}\n`,
         'utf8'
     ).catch((reason) => console.log(`writeLog`, reason));

--- a/packages/tosu/src/index.ts
+++ b/packages/tosu/src/index.ts
@@ -83,7 +83,7 @@ const currentVersion = require(process.cwd() + '/_version.js');
             1024 /
             1024;
 
-        if (size >= 500) {
+        if (size >= 100) {
             logs.forEach((file) => rmSync(join(logsPath, file)));
             wLogger.debug(
                 `The logs folder was cleared due to its size. (${size.toFixed(0)} MB)`

--- a/packages/tosu/src/index.ts
+++ b/packages/tosu/src/index.ts
@@ -7,6 +7,8 @@ import {
 } from '@tosu/common';
 import { Server } from '@tosu/server';
 import { autoUpdater, checkUpdates } from '@tosu/updater';
+import { existsSync, readdirSync, rmSync, statSync } from 'fs';
+import { dirname, join } from 'path';
 import { Process } from 'tsprocess';
 
 import { InstanceManager } from '@/instances/manager';
@@ -62,6 +64,30 @@ const currentVersion = require(process.cwd() + '/_version.js');
             );
             wLogger.warn('Please move tosu to different folder');
             return;
+        }
+    }
+
+    const logsPath = dirname(config.logFilePath);
+    if (existsSync(logsPath)) {
+        const logs = readdirSync(logsPath).filter(
+            (file) => file !== config.logFilePath.split('\\').pop()
+        );
+        const size =
+            logs.reduce((total, file) => {
+                const filePath = join(logsPath, file);
+                const fileSize = statSync(filePath).isFile()
+                    ? statSync(filePath).size
+                    : 0;
+                return total + fileSize;
+            }, 0) /
+            1024 /
+            1024;
+
+        if (size >= 500) {
+            logs.forEach((file) => rmSync(join(logsPath, file)));
+            wLogger.debug(
+                `The logs folder was cleared due to its size. (${size.toFixed(0)} MB)`
+            );
         }
     }
 


### PR DESCRIPTION
As discussed: if the folder exceeds 500MB, it's going to delete all files except the one currently in use.
The log message could be better tho, but whatever.

![image](https://github.com/user-attachments/assets/622d19c0-94df-4aad-b0b0-aa778c3ab8e7)
