### PR TITLE
feat: bump overlay lib, overlay process tweaks

### DIFF
--- a/packages/ingame-overlay/package.json
+++ b/packages/ingame-overlay/package.json
@@ -12,7 +12,7 @@
   "keywords": [],
   "author": "storycraft <storycraft@pancake.sh>",
   "dependencies": {
-    "asdf-overlay-node": "^0.6.7"
+    "asdf-overlay-node": "^0.7.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",

--- a/packages/ingame-overlay/src/index.ts
+++ b/packages/ingame-overlay/src/index.ts
@@ -14,11 +14,17 @@ import { OverlayManager } from './manager';
 
         console.log('warn: Starting...');
 
+        // disable default menu
+        Menu.setApplicationMenu(null);
+
         // prefer discrete gpu on laptop
         app.commandLine.appendSwitch('force_high_performance_gpu');
         // disable view scaling on hidpi
         app.commandLine.appendSwitch('high-dpi-support', '1');
         app.commandLine.appendSwitch('force-device-scale-factor', '1');
+        // run in process gpu, reduce overheads
+        app.commandLine.appendSwitch('in-process-gpu');
+        app.commandLine.appendSwitch('disable-direct-composition');
 
         // prevent main process from exiting when all windows are closed
         app.on('window-all-closed', () => {});

--- a/packages/ingame-overlay/src/input.ts
+++ b/packages/ingame-overlay/src/input.ts
@@ -54,22 +54,28 @@ export function toMouseEvent(
         case 'Enter':
             return {
                 type: 'mouseEnter',
-                x: input.x,
-                y: input.y
+                x: input.clientX,
+                y: input.clientY,
+                globalX: input.windowX,
+                globalY: input.windowY
             };
 
         case 'Leave':
             return {
                 type: 'mouseLeave',
-                x: input.x,
-                y: input.y
+                x: input.clientX,
+                y: input.clientY,
+                globalX: input.windowX,
+                globalY: input.windowY
             };
 
         case 'Move':
             return {
                 type: 'mouseMove',
-                x: input.x,
-                y: input.y
+                x: input.clientX,
+                y: input.clientY,
+                globalX: input.windowX,
+                globalY: input.windowY
             };
 
         case 'Scroll':
@@ -77,15 +83,19 @@ export function toMouseEvent(
                 return {
                     type: 'mouseWheel',
                     deltaY: input.delta,
-                    x: input.x,
-                    y: input.y
+                    x: input.clientX,
+                    y: input.clientY,
+                    globalX: input.windowX,
+                    globalY: input.windowY
                 };
             } else {
                 return {
                     type: 'mouseWheel',
                     deltaX: input.delta,
-                    x: input.x,
-                    y: input.y
+                    x: input.clientX,
+                    y: input.clientY,
+                    globalX: input.windowX,
+                    globalY: input.windowY
                 };
             }
 
@@ -112,8 +122,10 @@ export function toMouseEvent(
                 type: input.state === 'Pressed' ? 'mouseDown' : 'mouseUp',
                 button,
                 clickCount: 1,
-                x: input.x,
-                y: input.y
+                x: input.clientX,
+                y: input.clientY,
+                globalX: input.windowX,
+                globalY: input.windowY
             };
         }
     }

--- a/packages/ingame-overlay/src/process.ts
+++ b/packages/ingame-overlay/src/process.ts
@@ -115,6 +115,7 @@ export class OverlayProcess {
     private async updateSurface(info: TextureInfo) {
         const rect = info.metadata.captureUpdateRect ?? info.contentRect;
         await this.overlay.updateShtex(
+            this.hwnd,
             info.codedSize.width,
             info.codedSize.height,
             info.sharedTextureHandle,
@@ -132,7 +133,6 @@ export class OverlayProcess {
 
     static async initialize(pid: number): Promise<OverlayProcess> {
         const overlay = await Overlay.attach(
-            'tosu-ingame-overlay',
             defaultDllDir().replaceAll('app.asar', 'app.asar.unpacked'),
             pid,
             5000
@@ -146,9 +146,15 @@ export class OverlayProcess {
         );
         console.debug('found hwnd:', hwnd, 'for pid:', pid);
 
-        await overlay.setPosition(length(0), length(0));
-        await overlay.setAnchor(length(0), length(0));
-        await overlay.setMargin(length(0), length(0), length(0), length(0));
+        await overlay.setPosition(hwnd, length(0), length(0));
+        await overlay.setAnchor(hwnd, length(0), length(0));
+        await overlay.setMargin(
+            hwnd,
+            length(0),
+            length(0),
+            length(0),
+            length(0)
+        );
         // Listen for keyboard events
         await overlay.listenInput(hwnd, false, true);
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
   packages/ingame-overlay:
     dependencies:
       asdf-overlay-node:
-        specifier: ^0.6.7
-        version: 0.6.7
+        specifier: ^0.7.3
+        version: 0.7.3
     devDependencies:
       '@eslint/js':
         specifier: ^9.26.0
@@ -1163,8 +1163,9 @@ packages:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
     engines: {node: '>=0.10.0'}
 
-  asdf-overlay-node@0.6.7:
-    resolution: {integrity: sha512-G3SRLUmQQdPe4vW45Gx1Nnlzclu4HpwTR6QrH7cEflxsogWWTbBmoYX/nEiXTfQ54qX4oSHTWgxNQUGNtlmvZQ==}
+  asdf-overlay-node@0.7.3:
+    resolution: {integrity: sha512-+S21UTNFa80jCQIMWF0kx228bCxo63j5Smi4qtNSdqVJjRE32J1cQ5a8moDsRpFBhh3XC7Td2liE1Wdnfqf3Kg==}
+    cpu: [x64, arm64]
     os: [win32]
 
   assert-plus@1.0.0:
@@ -5258,7 +5259,7 @@ snapshots:
 
   arrify@1.0.1: {}
 
-  asdf-overlay-node@0.6.7: {}
+  asdf-overlay-node@0.7.3: {}
 
   assert-plus@1.0.0:
     optional: true


### PR DESCRIPTION
* remove window default menu
* apply `in-process-gpu` switch for less overhead
* update `asdf-overlay-node` to v0.7.3