### PR TITLE
feat: in-game overlay settings overhaul, max fps control, asyncify some mixed sync api

### DIFF
--- a/packages/common/utils/config.ts
+++ b/packages/common/utils/config.ts
@@ -1,5 +1,6 @@
 import * as dotenv from 'dotenv';
-import fs from 'fs';
+import syncFs from 'fs';
+import fs from 'node:fs/promises';
 import path from 'path';
 
 import { getProgramPath } from './directories';
@@ -9,15 +10,19 @@ import { wLogger } from './logger';
 const oldConfigPath = path.join(getProgramPath(), 'tsosu.env');
 const configPath = path.join(getProgramPath(), 'tosu.env');
 
-if (fs.existsSync(oldConfigPath) && !fs.existsSync(configPath)) {
-    fs.renameSync(oldConfigPath, configPath);
+if (syncFs.existsSync(oldConfigPath) && !syncFs.existsSync(configPath)) {
+    syncFs.renameSync(oldConfigPath, configPath);
 }
 
-const createConfig = () => {
-    if (!fs.existsSync(configPath)) {
-        fs.writeFileSync(
-            configPath,
-            `# The config implies a set of key-values to enable/disable tosu functionality
+const createConfig = async () => {
+    try {
+        await fs.access(configPath, fs.constants.F_OK);
+        return;
+    } catch {}
+
+    await fs.writeFile(
+        configPath,
+        `# The config implies a set of key-values to enable/disable tosu functionality
 # Below you can see that there is EVERY_THE_FUNCTION=true/false,
 # true = on
 # false = off
@@ -59,9 +64,8 @@ SERVER_IP=127.0.0.1
 SERVER_PORT=24050
 # The folder from which the overlays will be taken.
 STATIC_FOLDER_PATH=./static`,
-            'utf8'
-        );
-    }
+        'utf8'
+    );
 };
 
 dotenv.config({ path: configPath });
@@ -95,62 +99,74 @@ export const config = {
     logFilePath: ''
 };
 
-export const updateConfigFile = () => {
+export const updateConfigFile = async () => {
     let newOptions = '';
 
     if (!process.env.DEBUG_LOG) {
         newOptions += 'DEBUG_LOG, ';
-        fs.appendFileSync(configPath, '\nDEBUG_LOG=false', 'utf8');
+        await fs.appendFile(configPath, '\nDEBUG_LOG=false', 'utf8');
     }
 
     if (!process.env.CALCULATE_PP) {
         newOptions += 'CALCULATE_PP, ';
-        fs.appendFileSync(configPath, '\nCALCULATE_PP=true', 'utf8');
+        await fs.appendFile(configPath, '\nCALCULATE_PP=true', 'utf8');
     }
 
     if (!process.env.ENABLE_KEY_OVERLAY) {
         newOptions += 'ENABLE_KEY_OVERLAY, ';
-        fs.appendFileSync(configPath, '\nENABLE_KEY_OVERLAY=true', 'utf8');
+        await fs.appendFile(configPath, '\nENABLE_KEY_OVERLAY=true', 'utf8');
     }
 
     if (!process.env.POLL_RATE) {
         newOptions += 'POLL_RATE, ';
-        fs.appendFileSync(configPath, '\nPOLL_RATE=100', 'utf8');
+        await fs.appendFile(configPath, '\nPOLL_RATE=100', 'utf8');
     }
 
     if (!process.env.PRECISE_DATA_POLL_RATE) {
         newOptions += 'PRECISE_DATA_POLL_RATE, ';
-        fs.appendFileSync(configPath, '\n\nPRECISE_DATA_POLL_RATE=10', 'utf8');
+        await fs.appendFile(
+            configPath,
+            '\n\nPRECISE_DATA_POLL_RATE=10',
+            'utf8'
+        );
     }
 
     if (!process.env.SHOW_MP_COMMANDS) {
         newOptions += 'SHOW_MP_COMMANDS, ';
-        fs.appendFileSync(configPath, '\nSHOW_MP_COMMANDS=false', 'utf8');
+        await fs.appendFile(configPath, '\nSHOW_MP_COMMANDS=false', 'utf8');
     }
 
     if (!process.env.SERVER_IP) {
         newOptions += 'SERVER_IP, ';
-        fs.appendFileSync(configPath, '\nSERVER_IP=127.0.0.1', 'utf8');
+        await fs.appendFile(configPath, '\nSERVER_IP=127.0.0.1', 'utf8');
     }
 
     if (!process.env.SERVER_PORT) {
         newOptions += 'SERVER_PORT, ';
-        fs.appendFileSync(configPath, '\nSERVER_PORT=24050', 'utf8');
+        await fs.appendFile(configPath, '\nSERVER_PORT=24050', 'utf8');
     }
 
     if (!process.env.STATIC_FOLDER_PATH) {
         newOptions += 'STATIC_FOLDER_PATH, ';
-        fs.appendFileSync(configPath, '\nSTATIC_FOLDER_PATH=./static', 'utf8');
+        await fs.appendFile(
+            configPath,
+            '\nSTATIC_FOLDER_PATH=./static',
+            'utf8'
+        );
     }
 
     if (!process.env.ENABLE_INGAME_OVERLAY) {
         newOptions += 'ENABLE_INGAME_OVERLAY, ';
-        fs.appendFileSync(configPath, '\nENABLE_INGAME_OVERLAY=false', 'utf8');
+        await fs.appendFile(
+            configPath,
+            '\nENABLE_INGAME_OVERLAY=false',
+            'utf8'
+        );
     }
 
     if (!process.env.INGAME_OVERLAY_KEYBIND) {
         newOptions += 'INGAME_OVERLAY_KEYBIND, ';
-        fs.appendFileSync(
+        await fs.appendFile(
             configPath,
             '\nINGAME_OVERLAY_KEYBIND=Control + Shift + Space',
             'utf8'
@@ -159,17 +175,17 @@ export const updateConfigFile = () => {
 
     if (!process.env.INGAME_OVERLAY_MAX_FPS) {
         newOptions += 'INGAME_OVERLAY_MAX_FPS, ';
-        fs.appendFileSync(configPath, '\nINGAME_OVERLAY_MAX_FPS=60', 'utf8');
+        await fs.appendFile(configPath, '\nINGAME_OVERLAY_MAX_FPS=60', 'utf8');
     }
 
     if (!process.env.ENABLE_AUTOUPDATE) {
         newOptions += 'ENABLE_AUTOUPDATE, ';
-        fs.appendFileSync(configPath, '\nENABLE_AUTOUPDATE=true', 'utf8');
+        await fs.appendFile(configPath, '\nENABLE_AUTOUPDATE=true', 'utf8');
     }
 
     if (!process.env.OPEN_DASHBOARD_ON_STARTUP) {
         newOptions += 'OPEN_DASHBOARD_ON_STARTUP, ';
-        fs.appendFileSync(
+        await fs.appendFile(
             configPath,
             '\nOPEN_DASHBOARD_ON_STARTUP=true',
             'utf8'
@@ -178,7 +194,7 @@ export const updateConfigFile = () => {
 
     if (!process.env.ALLOWED_IPS) {
         newOptions += 'ALLOWED_IPS, ';
-        fs.appendFileSync(
+        await fs.appendFile(
             configPath,
             '\nALLOWED_IPS=127.0.0.1,localhost,absolute',
             'utf8'
@@ -193,26 +209,22 @@ export const updateConfigFile = () => {
     }
 };
 
-export const watchConfigFile = ({
+export const watchConfigFile = async ({
     httpServer,
     initial
 }: {
     httpServer: any;
     initial?: boolean;
 }) => {
+    await createConfig();
     if (initial === true) {
-        createConfig();
-        refreshConfig(httpServer, false);
-        updateConfigFile();
+        await refreshConfig(httpServer, false);
+        await updateConfigFile();
     }
 
-    if (!fs.existsSync(configPath)) {
-        createConfig();
-    }
-
-    const stat = fs.statSync(configPath);
+    const stat = await fs.stat(configPath);
     if (config.timestamp !== stat.mtimeMs) {
-        refreshConfig(httpServer, true);
+        await refreshConfig(httpServer, true);
         config.timestamp = stat.mtimeMs;
     }
 
@@ -221,7 +233,7 @@ export const watchConfigFile = ({
     }, 1000);
 };
 
-export const refreshConfig = (httpServer: any, refresh: boolean) => {
+export const refreshConfig = async (httpServer: any, refresh: boolean) => {
     let updated = false;
     const status = refresh === true ? 'reload' : 'load';
 
@@ -252,8 +264,7 @@ export const refreshConfig = (httpServer: any, refresh: boolean) => {
     const ingameOverlayMaxFps = Number(parsed.INGAME_OVERLAY_MAX_FPS || 60);
     const allowedIPs = parsed.ALLOWED_IPS || '127.0.0.1,localhost,absolute';
 
-    const isKeybindUpdated =
-        config.ingameOverlayKeybind !== ingameOverlayKeybind;
+    const maxFpsUpdated = config.ingameOverlayMaxFps !== ingameOverlayMaxFps;
     // determine whether config actually was updated or not
     updated =
         config.enableAutoUpdate !== enableAutoUpdate ||
@@ -266,7 +277,8 @@ export const refreshConfig = (httpServer: any, refresh: boolean) => {
         config.showMpCommands !== showMpCommands ||
         config.staticFolderPath !== staticFolderPath ||
         config.enableIngameOverlay !== enableIngameOverlay ||
-        isKeybindUpdated ||
+        config.ingameOverlayKeybind !== ingameOverlayKeybind ||
+        maxFpsUpdated ||
         config.serverIP !== serverIP ||
         config.serverPort !== serverPort ||
         config.allowedIPs !== allowedIPs;
@@ -281,14 +293,23 @@ export const refreshConfig = (httpServer: any, refresh: boolean) => {
     config.enableIngameOverlay = enableIngameOverlay;
     config.ingameOverlayKeybind = ingameOverlayKeybind;
     config.ingameOverlayMaxFps = ingameOverlayMaxFps;
-    checkGameOverlayConfig();
+    await checkGameOverlayConfig();
 
     if (enableIngameOverlay) {
-        if (Object.keys(httpServer.instanceManager.osuInstances).length > 0) {
-            httpServer.instanceManager.startOverlay(isKeybindUpdated);
+        if (httpServer.instanceManager.overlayProcess) {
+            if (maxFpsUpdated) {
+                // setFrameRate doesn't work after paint event.
+                // overlay must be restarted in this case.
+                await httpServer.instanceManager.stopOverlay();
+                await httpServer.instanceManager.startOverlay();
+            } else {
+                httpServer.instanceManager.updateOverlayConfig();
+            }
+        } else {
+            await httpServer.instanceManager.startOverlay();
         }
     } else {
-        httpServer.instanceManager.stopOverlay();
+        await httpServer.instanceManager.stopOverlay();
     }
 
     if (enableGosuOverlay === true && !enableIngameOverlay) {
@@ -310,14 +331,14 @@ export const refreshConfig = (httpServer: any, refresh: boolean) => {
     config.allowedIPs = allowedIPs;
 
     const staticPath = path.join(getProgramPath(), 'static');
-    if (config.staticFolderPath === './static' && !fs.existsSync(staticPath)) {
-        fs.mkdirSync(staticPath);
+    if (config.staticFolderPath === './static') {
+        await fs.mkdir(staticPath, { recursive: true });
     }
 
     if (updated) wLogger.info('[config]', `Config ${status}ed`);
 };
 
-export const writeConfig = (httpServer: any, options: any) => {
+export const writeConfig = async (httpServer: any, options: any) => {
     let text = '';
 
     text += `DEBUG_LOG=${options.DEBUG_LOG ?? config.debugLogging}\n\n`;
@@ -336,7 +357,6 @@ export const writeConfig = (httpServer: any, options: any) => {
     text += `SERVER_PORT=${options.SERVER_PORT ?? config.serverPort}\n\n`;
     text += `STATIC_FOLDER_PATH=${options.STATIC_FOLDER_PATH ?? config.staticFolderPath}\n`;
 
-    fs.writeFile(configPath, text, 'utf8', () => {
-        refreshConfig(httpServer, true);
-    });
+    await fs.writeFile(configPath, text, 'utf8');
+    await refreshConfig(httpServer, true);
 };

--- a/packages/common/utils/config.ts
+++ b/packages/common/utils/config.ts
@@ -42,6 +42,7 @@ SHOW_MP_COMMANDS=false
 # Enables/disables the in-game overlay (!!!I AM NOT RESPONSIBLE FOR USING IT!!!).
 ENABLE_INGAME_OVERLAY=false
 INGAME_OVERLAY_KEYBIND=Control + Shift + Space
+INGAME_OVERLAY_MAX_FPS=60
 
 # WARNING: EVERYTHING BELOW IS NOT TO BE TOUCHED UNNECESSARILY.
 
@@ -86,6 +87,7 @@ export const config = {
     enableIngameOverlay: (process.env.ENABLE_INGAME_OVERLAY || '') === 'true',
     ingameOverlayKeybind:
         process.env.INGAME_OVERLAY_KEYBIND || 'Control + Shift + Space',
+    ingameOverlayMaxFps: Number(process.env.INGAME_OVERLAY_MAX_FPS || 60),
     allowedIPs: process.env.ALLOWED_IPS || '127.0.0.1,localhost,absolute',
     timestamp: 0,
     currentVersion: '',
@@ -153,6 +155,11 @@ export const updateConfigFile = () => {
             '\nINGAME_OVERLAY_KEYBIND=Control + Shift + Space',
             'utf8'
         );
+    }
+
+    if (!process.env.INGAME_OVERLAY_MAX_FPS) {
+        newOptions += 'INGAME_OVERLAY_MAX_FPS, ';
+        fs.appendFileSync(configPath, '\nINGAME_OVERLAY_MAX_FPS=60', 'utf8');
     }
 
     if (!process.env.ENABLE_AUTOUPDATE) {
@@ -242,6 +249,7 @@ export const refreshConfig = (httpServer: any, refresh: boolean) => {
     const enableIngameOverlay = (parsed.ENABLE_INGAME_OVERLAY || '') === 'true';
     const ingameOverlayKeybind =
         parsed.INGAME_OVERLAY_KEYBIND || 'Control + Shift + Space';
+    const ingameOverlayMaxFps = Number(parsed.INGAME_OVERLAY_MAX_FPS || 60);
     const allowedIPs = parsed.ALLOWED_IPS || '127.0.0.1,localhost,absolute';
 
     const isKeybindUpdated =
@@ -272,6 +280,7 @@ export const refreshConfig = (httpServer: any, refresh: boolean) => {
 
     config.enableIngameOverlay = enableIngameOverlay;
     config.ingameOverlayKeybind = ingameOverlayKeybind;
+    config.ingameOverlayMaxFps = ingameOverlayMaxFps;
     checkGameOverlayConfig();
 
     if (enableIngameOverlay) {
@@ -317,6 +326,7 @@ export const writeConfig = (httpServer: any, options: any) => {
     text += `OPEN_DASHBOARD_ON_STARTUP=${options.OPEN_DASHBOARD_ON_STARTUP ?? config.openDashboardOnStartup}\n\n`;
     text += `ENABLE_INGAME_OVERLAY=${options.ENABLE_INGAME_OVERLAY ?? config.enableIngameOverlay}\n`;
     text += `INGAME_OVERLAY_KEYBIND=${options.INGAME_OVERLAY_KEYBIND ?? config.ingameOverlayKeybind}\n`;
+    text += `INGAME_OVERLAY_MAX_FPS=${options.INGAME_OVERLAY_MAX_FPS ?? config.ingameOverlayMaxFps}\n`;
     text += `ENABLE_KEY_OVERLAY=${options.ENABLE_KEY_OVERLAY ?? config.enableKeyOverlay}\n\n`;
     text += `ALLOWED_IPS=${options.ALLOWED_IPS ?? config.allowedIPs}\n\n`;
     text += `POLL_RATE=${options.POLL_RATE ?? config.pollRate}\n`;

--- a/packages/common/utils/ingame.ts
+++ b/packages/common/utils/ingame.ts
@@ -1,10 +1,12 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 
 import { getSettingsPath } from './directories';
 
-export const checkGameOverlayConfig = () => {
+export const checkGameOverlayConfig = async () => {
     const newestConfigPath = getSettingsPath('__ingame__');
-    if (fs.existsSync(newestConfigPath)) return;
-
-    fs.writeFileSync(newestConfigPath, '{}', 'utf8');
+    try {
+        await fs.access(newestConfigPath, fs.constants.F_OK);
+    } catch {
+        await fs.writeFile(newestConfigPath, '{}', 'utf8');
+    }
 };

--- a/packages/ingame-overlay-updater/src/index.ts
+++ b/packages/ingame-overlay-updater/src/index.ts
@@ -23,7 +23,7 @@ export async function runOverlay(): Promise<ChildProcess> {
         );
     }
 
-    checkGameOverlayConfig();
+    await checkGameOverlayConfig();
 
     const gameOverlayPath = path.join(getProgramPath(), 'game-overlay');
     if (

--- a/packages/ingame-overlay/package.json
+++ b/packages/ingame-overlay/package.json
@@ -12,7 +12,7 @@
   "keywords": [],
   "author": "storycraft <storycraft@pancake.sh>",
   "dependencies": {
-    "asdf-overlay-node": "^0.7.3"
+    "asdf-overlay-node": "^0.7.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",

--- a/packages/ingame-overlay/src/manager.ts
+++ b/packages/ingame-overlay/src/manager.ts
@@ -86,13 +86,21 @@ export class OverlayManager {
         );
     }
 
+    updateMaxFps(maxFps: number) {
+        for (const overlay of this.map.values()) {
+            overlay.window.webContents.setFrameRate(maxFps);
+        }
+
+        console.debug(`MaxFps updated to ${maxFps}`);
+    }
+
     async handleEvent(message: { cmd: string } & Record<string, unknown>) {
         if (message.cmd === 'add') {
             await this.runOverlay(message.pid as number);
-        }
-
-        if (message.cmd === 'keybind') {
+        } else if (message.cmd === 'keybind') {
             this.updateKeybind(message.keybind as string);
+        } else if (message.cmd === 'maxFps') {
+            this.updateMaxFps(message.maxFps as number);
         }
     }
 }

--- a/packages/server/router/index.ts
+++ b/packages/server/router/index.ts
@@ -340,14 +340,14 @@ export default function buildBaseApi(server: Server) {
         autoUpdater('server', res)
     );
 
-    server.app.route('/api/settingsSave', 'POST', (req, res) => {
+    server.app.route('/api/settingsSave', 'POST', async (req, res) => {
         const body: object | Error = JsonSafeParse(
             req.body,
             new Error('Failed to parse body')
         );
         if (body instanceof Error) throw body;
 
-        writeConfig(server, body);
+        await writeConfig(server, body);
         return sendJson(res, { status: 'updated' });
     });
 

--- a/packages/server/utils/counters.ts
+++ b/packages/server/utils/counters.ts
@@ -580,28 +580,6 @@ export function buildSettings(res: http.ServerResponse) {
                                 '{checked}',
                                 config.openDashboardOnStartup ? 'checked' : ''
                             )
-                    ),
-                settingsItemHTMLv2
-                    .replace('{name}', 'In-Game Overlay')
-                    .replace(
-                        '{description}',
-                        'Show the in-game overlay in the game, toggleable via a custom keybind.'
-                    )
-                    .replace(
-                        '{input-1}',
-                        settingsSwitchHTML
-                            .replace('{id}', 'ENABLE_INGAME_OVERLAY')
-                            .replace(
-                                '{checked}',
-                                config.enableIngameOverlay ? 'checked' : ''
-                            )
-                    )
-                    .replace(
-                        '{input-2}',
-                        settingsTextInputHTML
-                            .replace('{id}', 'INGAME_OVERLAY_KEYBIND')
-                            .replace('{class}', ' -keybind')
-                            .replace('{value}', config.ingameOverlayKeybind)
                     )
             ]
                 .map((item) => item.replace(/\{[^}]*}/g, ''))
@@ -739,6 +717,60 @@ export function buildSettings(res: http.ServerResponse) {
                 .join('\n')
         );
 
+    const ingameOverlayGroup = settingsGroupHTML
+        .replace('{header}', 'In-Game Overlay')
+        .replace(
+            '{items}',
+            [
+                settingsItemHTMLv2
+                    .replace('{name}', 'Enable In-Game Overlay')
+                    .replace(
+                        '{description}',
+                        'Show the in-game overlay in the game.'
+                    )
+                    .replace(
+                        '{input-1}',
+                        settingsSwitchHTML
+                            .replace('{id}', 'ENABLE_INGAME_OVERLAY')
+                            .replace(
+                                '{checked}',
+                                config.enableIngameOverlay ? 'checked' : ''
+                            )
+                    ),
+                settingsItemHTMLv2
+                    .replace('{name}', 'Config Mode Keybind')
+                    .replace(
+                        '{description}',
+                        'Keybind to toggle config mode for customizing in-game overlay placement.'
+                    )
+                    .replace(
+                        '{input-2}',
+                        settingsTextInputHTML
+                            .replace('{id}', 'INGAME_OVERLAY_KEYBIND')
+                            .replace('{class}', ' -keybind')
+                            .replace('{value}', config.ingameOverlayKeybind)
+                    ),
+                settingsItemHTMLv2
+                    .replace('{name}', 'Maximum Fps')
+                    .replace(
+                        '{description}',
+                        'Maximum frame rate of in-game overlay. High value may negatively impact performance.'
+                    )
+                    .replace(
+                        '{input-2}',
+                        settingsNumberInputHTML
+                            .replace('{id}', 'INGAME_OVERLAY_MAX_FPS')
+                            .replace('{min}', '0')
+                            .replace(
+                                '{value}',
+                                String(config.ingameOverlayMaxFps)
+                            )
+                    )
+            ]
+                .map((item) => item.replace(/\{[^}]*}/g, ''))
+                .join('\n')
+        );
+
     const advancedGroup = settingsGroupHTML
         .replace('{header}', 'Advanced')
         .replace(
@@ -792,7 +824,13 @@ export function buildSettings(res: http.ServerResponse) {
                 .join('\n')
         );
 
-    const groups = [generalGroup, dataGroup, serverGroup, advancedGroup]
+    const groups = [
+        generalGroup,
+        dataGroup,
+        serverGroup,
+        ingameOverlayGroup,
+        advancedGroup
+    ]
         .map((item) => item.replace(/\{[^}]*}/g, ''))
         .join('\n');
 

--- a/packages/tosu/src/index.ts
+++ b/packages/tosu/src/index.ts
@@ -25,7 +25,7 @@ const currentVersion = require(process.cwd() + '/_version.js');
     const instanceManager = new InstanceManager();
     const httpServer = new Server({ instanceManager });
 
-    watchConfigFile({ httpServer, initial: true });
+    await watchConfigFile({ httpServer, initial: true });
 
     const { update, onedrive: onedriveBypass } = argumentsParser(process.argv);
 

--- a/packages/tosu/src/instances/manager.ts
+++ b/packages/tosu/src/instances/manager.ts
@@ -149,6 +149,11 @@ export class InstanceManager {
                         cmd: 'keybind',
                         keybind: config.ingameOverlayKeybind
                     });
+
+                    this.overlayProcess?.send({
+                        cmd: 'maxFps',
+                        maxFps: config.ingameOverlayMaxFps
+                    });
                 }
             }
         } catch (exc) {

--- a/packages/tosu/src/instances/manager.ts
+++ b/packages/tosu/src/instances/manager.ts
@@ -235,14 +235,16 @@ export class InstanceManager {
         });
     }
 
-    stopOverlay() {
+    async stopOverlay() {
         // ignore if it's not started
         if (!this.overlayProcess) {
             return;
         }
 
         wLogger.warn('[ingame-overlay]', 'Stopping...');
-        this.overlayProcess.kill();
+        const overlayProcess = this.overlayProcess;
+        overlayProcess.kill();
+        await new Promise((resolve) => overlayProcess.once('close', resolve));
         this.overlayProcess = null;
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
   packages/ingame-overlay:
     dependencies:
       asdf-overlay-node:
-        specifier: ^0.7.3
-        version: 0.7.3
+        specifier: ^0.7.5
+        version: 0.7.5
     devDependencies:
       '@eslint/js':
         specifier: ^9.26.0
@@ -1163,8 +1163,8 @@ packages:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
     engines: {node: '>=0.10.0'}
 
-  asdf-overlay-node@0.7.3:
-    resolution: {integrity: sha512-+S21UTNFa80jCQIMWF0kx228bCxo63j5Smi4qtNSdqVJjRE32J1cQ5a8moDsRpFBhh3XC7Td2liE1Wdnfqf3Kg==}
+  asdf-overlay-node@0.7.5:
+    resolution: {integrity: sha512-xJd7J0aXakCpKDmO+XYbnc1prh3wnEcn0s2IRWeSphZltvCOvmDwRwh3hnXcBf5s7yjhANcg+53hyC37hrbJtA==}
     cpu: [x64, arm64]
     os: [win32]
 
@@ -5259,7 +5259,7 @@ snapshots:
 
   arrify@1.0.1: {}
 
-  asdf-overlay-node@0.7.3: {}
+  asdf-overlay-node@0.7.5: {}
 
   assert-plus@1.0.0:
     optional: true


### PR DESCRIPTION
* Fix #399
* Dedicated in-game overlay settings group
![image](https://github.com/user-attachments/assets/376889b2-325a-4d64-873b-3e75814ca961)
* New in-game overlay max fps settings
* Fix in-game overlay does not render on previously launched osu instances when restarting
* Asyncify config api. Fix some un-noticable bugs due to improper mixed sync, async usage
  * Fix config refreshing twice on startup
  * Fix checking `createConfig` twice