### PR TITLE
chore: update overlay deps

### DIFF
--- a/packages/ingame-overlay/package.json
+++ b/packages/ingame-overlay/package.json
@@ -12,7 +12,7 @@
   "keywords": [],
   "author": "storycraft <storycraft@pancake.sh>",
   "dependencies": {
-    "asdf-overlay-node": "^0.7.9"
+    "asdf-overlay-node": "^0.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",

--- a/packages/ingame-overlay/src/input.ts
+++ b/packages/ingame-overlay/src/input.ts
@@ -152,6 +152,18 @@ export function toKeyboardEvent(
                 type: 'char',
                 keyCode: input.ch
             };
+
+        case 'Ime': {
+            // TODO:: proper ime handling
+            if (input.ime.kind === 'Commit') {
+                return {
+                    type: 'char',
+                    keyCode: input.ime.text
+                };
+            }
+
+            return null;
+        }
     }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
   packages/ingame-overlay:
     dependencies:
       asdf-overlay-node:
-        specifier: ^0.7.9
-        version: 0.7.9
+        specifier: ^0.8.1
+        version: 0.8.1
     devDependencies:
       '@eslint/js':
         specifier: ^9.26.0
@@ -1179,8 +1179,8 @@ packages:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
     engines: {node: '>=0.10.0'}
 
-  asdf-overlay-node@0.7.9:
-    resolution: {integrity: sha512-mjgBVIXdukzNFNQ3jP14YAvsVkRlwz1CXEy0LTTLd82lyaOrM62fa6t2xzCX75bzJHi2Rm+Nfa4MRKvGwADcmw==}
+  asdf-overlay-node@0.8.1:
+    resolution: {integrity: sha512-ix0QZ/G3bkdLZXpyjeTNhnmy/TpshlslvOgC/eTtrfHZLWW2aN5cr7TCZFUE12PseXTPewdujAVOCgmF6gyISQ==}
     cpu: [x64, arm64]
     os: [win32]
 
@@ -5290,7 +5290,7 @@ snapshots:
 
   arrify@1.0.1: {}
 
-  asdf-overlay-node@0.7.9: {}
+  asdf-overlay-node@0.8.1: {}
 
   assert-plus@1.0.0:
     optional: true


### PR DESCRIPTION
* Zerocopy rendering on compatibility mode. Boosts performance just like non-compatibility mode.
* Show cursors immediately when opening configuration mode.
* Cursor inputs are captured correctly when dragging from inside to outside of window(like actual browser).