### PR TITLE
feat: embed vcrt in overlay dll

### DIFF
--- a/packages/ingame-overlay/package.json
+++ b/packages/ingame-overlay/package.json
@@ -12,7 +12,7 @@
   "keywords": [],
   "author": "storycraft <storycraft@pancake.sh>",
   "dependencies": {
-    "asdf-overlay-node": "^0.8.1"
+    "asdf-overlay-node": "^0.8.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.26.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
   packages/ingame-overlay:
     dependencies:
       asdf-overlay-node:
-        specifier: ^0.8.1
-        version: 0.8.1
+        specifier: ^0.8.2
+        version: 0.8.2
     devDependencies:
       '@eslint/js':
         specifier: ^9.26.0
@@ -1179,8 +1179,8 @@ packages:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
     engines: {node: '>=0.10.0'}
 
-  asdf-overlay-node@0.8.1:
-    resolution: {integrity: sha512-ix0QZ/G3bkdLZXpyjeTNhnmy/TpshlslvOgC/eTtrfHZLWW2aN5cr7TCZFUE12PseXTPewdujAVOCgmF6gyISQ==}
+  asdf-overlay-node@0.8.2:
+    resolution: {integrity: sha512-M+HirgtygI5PnUDixoEWFluiu3s/+vfAN5D6RZ1BRnZPkwQEl1wrvZvtbCRPxbw2yN62i0wB54JAjvOxUQhrOw==}
     cpu: [x64, arm64]
     os: [win32]
 
@@ -5290,7 +5290,7 @@ snapshots:
 
   arrify@1.0.1: {}
 
-  asdf-overlay-node@0.8.1: {}
+  asdf-overlay-node@0.8.2: {}
 
   assert-plus@1.0.0:
     optional: true


### PR DESCRIPTION
Embed vcrt in overlay dll so it doesn't fail silently without `vcruntime140.dll` installed.

* bump `asdf-overlay` to v0.8.2