### PR TITLE
fix: ensure paths are sanitized correctly.

### DIFF
--- a/packages/tosu/src/instances/index.ts
+++ b/packages/tosu/src/instances/index.ts
@@ -18,7 +18,7 @@ import { ResultScreen } from '@/states/resultScreen';
 import { Settings } from '@/states/settings';
 import { TourneyManager } from '@/states/tourney';
 import { User } from '@/states/user';
-import { cleanPath } from '@/utils/converters';
+import { safeJoin } from '@/utils/converters';
 
 export interface DataRepoList {
     settings: Settings;
@@ -65,7 +65,7 @@ export abstract class AbstractInstance {
         this.pid = pid;
 
         this.process = new Process(this.pid, bitness);
-        this.path = cleanPath(this.process.path);
+        this.path = safeJoin(this.process.path);
         this.bitness = bitness;
 
         this.client =

--- a/packages/tosu/src/instances/osuInstance.ts
+++ b/packages/tosu/src/instances/osuInstance.ts
@@ -10,7 +10,7 @@ import fs from 'fs';
 
 import { AbstractInstance } from '@/instances/index';
 import { StableMemory } from '@/memory/stable';
-import { cleanPath } from '@/utils/converters';
+import { safeJoin } from '@/utils/converters';
 
 export class OsuInstance extends AbstractInstance {
     memory: StableMemory;
@@ -65,7 +65,7 @@ export class OsuInstance extends AbstractInstance {
                         global.setSongsFolder(global.memorySongsFolder);
                     } else {
                         global.setSongsFolder(
-                            cleanPath(this.path, global.memorySongsFolder)
+                            safeJoin(this.path, global.memorySongsFolder)
                         );
                     }
                 }

--- a/packages/tosu/src/states/beatmap.ts
+++ b/packages/tosu/src/states/beatmap.ts
@@ -7,7 +7,7 @@ import { BeatmapDecoder } from 'osu-parsers';
 import { BeatmapStrains } from '@/api/types/v1';
 import { AbstractInstance } from '@/instances';
 import { AbstractState } from '@/states';
-import { cleanPath, fixDecimals } from '@/utils/converters';
+import { fixDecimals, safeJoin } from '@/utils/converters';
 import { sanitizeMods } from '@/utils/osuMods';
 import { CalculateMods, ModsLazer } from '@/utils/osuMods.types';
 
@@ -345,7 +345,7 @@ export class BeatmapPP extends AbstractState {
                 return;
             }
 
-            const mapPath = cleanPath(
+            const mapPath = safeJoin(
                 global.songsFolder,
                 menu.folder,
                 menu.filename
@@ -486,11 +486,11 @@ export class BeatmapPP extends AbstractState {
                 const { bpm, bpmMin, bpmMax } = this.lazerBeatmap;
 
                 if (
-                    cleanPath(this.lazerBeatmap.events.backgroundPath || '') !==
+                    safeJoin(this.lazerBeatmap.events.backgroundPath || '') !==
                         menu.backgroundFilename &&
                     !lazerBypass
                 ) {
-                    menu.backgroundFilename = cleanPath(
+                    menu.backgroundFilename = safeJoin(
                         this.lazerBeatmap.events.backgroundPath || ''
                     );
                 }

--- a/packages/tosu/src/states/global.ts
+++ b/packages/tosu/src/states/global.ts
@@ -1,7 +1,7 @@
 import { ClientType, measureTime, wLogger } from '@tosu/common';
 
 import { AbstractState } from '@/states';
-import { cleanPath } from '@/utils/converters';
+import { safeJoin } from '@/utils/converters';
 import { defaultCalculatedMods } from '@/utils/osuMods';
 import { CalculateMods } from '@/utils/osuMods.types';
 
@@ -64,8 +64,8 @@ export class Global extends AbstractState {
             this.gameTime = result.gameTime;
             this.menuMods = result.menuMods;
 
-            this.skinFolder = cleanPath(result.skinFolder);
-            this.memorySongsFolder = cleanPath(result.memorySongsFolder);
+            this.skinFolder = safeJoin(result.skinFolder);
+            this.memorySongsFolder = safeJoin(result.memorySongsFolder);
 
             this.game.resetReportCount('global updateState');
         } catch (exc) {

--- a/packages/tosu/src/states/menu.ts
+++ b/packages/tosu/src/states/menu.ts
@@ -1,7 +1,7 @@
 import { ClientType, measureTime, wLogger } from '@tosu/common';
 
 import { AbstractState } from '@/states';
-import { cleanPath } from '@/utils/converters';
+import { safeJoin } from '@/utils/converters';
 
 export class Menu extends AbstractState {
     gamemode: number;
@@ -79,7 +79,7 @@ export class Menu extends AbstractState {
 
             // MD5 hasn't changed in over NEW_MAP_COMMIT_DELAY, commit to new map
             this.checksum = result.checksum;
-            this.filename = cleanPath(result.filename);
+            this.filename = safeJoin(result.filename);
 
             this.plays = result.plays;
             this.artist = result.artist;
@@ -92,13 +92,13 @@ export class Menu extends AbstractState {
             this.hp = result.hp;
             this.od = result.od;
 
-            this.audioFilename = cleanPath(result.audioFilename);
+            this.audioFilename = safeJoin(result.audioFilename);
             this.audioFileMimetype = result.audioFileMimetype;
 
-            this.backgroundFilename = cleanPath(result.backgroundFilename);
+            this.backgroundFilename = safeJoin(result.backgroundFilename);
             this.backgroundFileMimetype = result.backgroundFileMimetype;
 
-            this.folder = cleanPath(result.folder);
+            this.folder = safeJoin(result.folder);
             this.creator = result.creator;
             this.difficulty = result.difficulty;
             this.mapID = result.mapID;

--- a/packages/tosu/src/utils/converters.ts
+++ b/packages/tosu/src/utils/converters.ts
@@ -80,23 +80,16 @@ export const numberFromDecimal = (
 };
 
 /**
- * Joins given paths safely, removes invalid characters, uses system path separator and normalizes the joined path.
+ * Joins given paths safely, uses system path separator and normalizes the joined path.
  *
  * @param {...string} paths - The paths to join.
  * @returns {string} The safely joined path.
  */
 export const safeJoin = (...paths: string[]): string => {
-    const invalidChars = process.platform === 'win32' ? /[<>?"*|]/g : /[\\0/]/g;
-
     const cleaned = paths.map((path) => {
         if (!path) return '';
-
-        return path
-            .trim()
-            .replace(/[/\\]+/g, sep)
-            .replace(invalidChars, '');
+        return path.trim().replace(/[/\\]+/g, sep);
     });
 
-    const result = join(...cleaned);
-    return normalize(result);
+    return normalize(join(...cleaned));
 };

--- a/packages/tosu/src/utils/converters.ts
+++ b/packages/tosu/src/utils/converters.ts
@@ -79,6 +79,12 @@ export const numberFromDecimal = (
     return value;
 };
 
+/**
+ * Joins given paths safely, removes invalid characters, uses system path separator and normalizes the joined path.
+ *
+ * @param {...string} paths - The paths to join.
+ * @returns {string} The safely joined path.
+ */
 export const safeJoin = (...paths: string[]): string => {
     const invalidChars = process.platform === 'win32' ? /[<>?"*|]/g : /[\\0/]/g;
 


### PR DESCRIPTION
- function now actually does something (blame it on me, I'm the culprit)
- changed it's name to actually represent what it does.
- it's now using the system's path separator and depends on nodejs to normalize it to utf-8

things I have to do bef merge:
- [x] add back jsdoc