### PR TITLE
fix: Fix trying to read nonexistent "Classic" mod's settings in osu!mania

### DIFF
--- a/packages/tosu/src/memory/lazer.ts
+++ b/packages/tosu/src/memory/lazer.ts
@@ -2415,7 +2415,7 @@ export class LazerMemory extends AbstractMemory<LazerPatternData> {
                 break;
             }
             case 'CL': {
-                if (this.selectedGamemode === 1) break;
+                if (this.selectedGamemode !== 0) break;
                 const noSliderHeadAccuracyBindable = this.process.readIntPtr(
                     modObject + 0x10
                 );


### PR DESCRIPTION
Stumbled upon it while trying to fix/update my overlay. I thought that the "Classic" mod in mania had settings in the past, but I guess [that's not the case](https://github.com/ppy/osu/commits/master/osu.Game.Rulesets.Mania/Mods/ManiaModClassic.cs)