### PR TITLE
chore: Update osu!(lazer) mods' settings

### DIFF
--- a/packages/tosu/src/memory/lazer.ts
+++ b/packages/tosu/src/memory/lazer.ts
@@ -2194,25 +2194,49 @@ export class LazerMemory extends AbstractMemory<LazerPatternData> {
                 break;
             }
             case 'SD': {
+                const settings: any = {};
                 const restartBindable = this.process.readIntPtr(
                     modObject + 0x10
                 );
 
-                mod.settings = {
-                    restart: this.process.readByte(restartBindable + 0x40) === 1
-                };
+                const failOnSliderTailBindable = this.process.readIntPtr(
+                    modObject + 0x20
+                );
 
+                if (this.selectedGamemode === 0) {
+                    settings.fail_on_slider_tail =
+                        this.process.readByte(
+                            failOnSliderTailBindable + 0x40
+                        ) === 1;
+                }
+
+                settings.restart =
+                    this.process.readByte(restartBindable + 0x40) === 1;
+
+                mod.settings = settings;
                 break;
             }
             case 'PF': {
+                const settings: any = {};
                 const restartBindable = this.process.readIntPtr(
                     modObject + 0x10
                 );
 
-                mod.settings = {
-                    restart: this.process.readByte(restartBindable + 0x40) === 1
-                };
+                const requirePerfectHitsBindable = this.process.readIntPtr(
+                    modObject + 0x20
+                );
 
+                if (this.selectedGamemode === 3) {
+                    settings.require_perfect_hits =
+                        this.process.readByte(
+                            requirePerfectHitsBindable + 0x40
+                        ) === 1;
+                }
+
+                settings.restart =
+                    this.process.readByte(restartBindable + 0x40) === 1;
+
+                mod.settings = settings;
                 break;
             }
             case 'DT': {
@@ -2580,7 +2604,7 @@ export class LazerMemory extends AbstractMemory<LazerPatternData> {
                     spin_speed: this.process.readDouble(
                         spinSpeedBindable + 0x40
                     ),
-                    direction: this.process.readInt(directionBindable + 0x40)
+                    direction: `${this.process.readInt(directionBindable + 0x40)}`
                 };
                 break;
             }
@@ -2590,7 +2614,7 @@ export class LazerMemory extends AbstractMemory<LazerPatternData> {
 
                 mod.settings = {
                     scale: this.process.readFloat(scaleBindable + 0x40),
-                    style: this.process.readInt(styleBindable + 0x40)
+                    style: `${this.process.readInt(styleBindable + 0x40)}`
                 };
                 break;
             }
@@ -2715,7 +2739,7 @@ export class LazerMemory extends AbstractMemory<LazerPatternData> {
 
                 mod.settings = {
                     coverage: this.process.readFloat(coverageBindable + 0x40),
-                    direction: this.process.readInt(directionBindable + 0x40)
+                    direction: `${this.process.readInt(directionBindable + 0x40)}`
                 };
                 break;
             }

--- a/packages/tosu/src/utils/osuMods.ts
+++ b/packages/tosu/src/utils/osuMods.ts
@@ -283,6 +283,12 @@ export const calculateMods = (
 
         if (r.settings?.reflection !== undefined)
             r.settings.reflection = r.settings.reflection.toString();
+
+        if (r.settings?.direction !== undefined)
+            r.settings.direction = r.settings.direction.toString();
+
+        if (r.settings?.style !== undefined)
+            r.settings.style = r.settings.style.toString();
     });
 
     const settingsSpeedChange = (ModsLazer as any).find(

--- a/packages/tosu/src/utils/osuMods.types.ts
+++ b/packages/tosu/src/utils/osuMods.types.ts
@@ -337,6 +337,7 @@ export interface HR {
 export interface SD {
     acronym: 'SD';
     settings?: {
+        fail_on_slider_tail?: boolean;
         restart: boolean;
     };
 }
@@ -344,6 +345,7 @@ export interface SD {
 export interface PF {
     acronym: 'PF';
     settings?: {
+        require_perfect_hits?: boolean;
         restart: boolean;
     };
 }
@@ -539,7 +541,7 @@ export interface BR {
     acronym: 'BR';
     settings?: {
         spin_speed?: number;
-        direction?: number;
+        direction?: string;
     };
 }
 
@@ -547,7 +549,7 @@ export interface AD {
     acronym: 'AD';
     settings?: {
         scale?: number;
-        style?: number;
+        style?: string;
     };
 }
 
@@ -638,7 +640,7 @@ export interface CO {
     acronym: 'CO';
     settings?: {
         coverage?: number;
-        direction?: number;
+        direction?: string;
     };
 }
 


### PR DESCRIPTION
- Adds "[Also fail when missing a slider tail](https://github.com/ppy/osu/blob/20dbe096e03e043143388eab62e1650a3be1ea2a/osu.Game.Rulesets.Osu/Mods/OsuModSuddenDeath.cs#L22-L23)" in osu!standard's "Sudden Death" and "[Require perfect hits](https://github.com/ppy/osu/blob/1e61abde7498e7d101dfa81b149ddc4d49d3fa36/osu.Game.Rulesets.Mania/Mods/ManiaModPerfect.cs#L14-L15)" in osu!mania's "Perfect"
- Fixes "Style" in osu!standard's "[Approach Different](https://github.com/MaxOhn/rosu-mods/blob/6c5634488a076b35a1a0e8e9de6e7fefc7b05985/src/generated_mods.rs#L373-L379)" and "Direction" in both osu!standard's "[Barrel Roll](https://github.com/MaxOhn/rosu-mods/blob/6c5634488a076b35a1a0e8e9de6e7fefc7b05985/src/generated_mods.rs#L360-L366)" and osu!mania's "[Cover](https://github.com/MaxOhn/rosu-mods/blob/6c5634488a076b35a1a0e8e9de6e7fefc7b05985/src/generated_mods.rs#L1097-L1103)" being the wrong type

---

NOTE: `rosu-mods` (and therefore `rosu-pp` by extension) are "[not aware](https://github.com/MaxOhn/rosu-mods/blob/6c5634488a076b35a1a0e8e9de6e7fefc7b05985/src/generated_mods.rs#L1053-L1057)" of the "Require perfect hits" setting, so they think it's not valid. This breaks various fields that rosu calculates/provides when the setting is enabled. So my question is: should I comment out the memory reading part or leave it as is?

https://github.com/user-attachments/assets/18acf54f-0df7-4e01-a101-2d64c82e81fa