### PR TITLE
fix: ensure directory url end with trailing slash

### DIFF
--- a/packages/server/utils/directories.ts
+++ b/packages/server/utils/directories.ts
@@ -45,6 +45,14 @@ export function directoryWalker({
     const isHTML = filePath.endsWith('.html');
 
     if (isDirectory) {
+        if (!baseUrl.endsWith('/')) {
+            res.writeHead(301, {
+                Location: baseUrl + '/'
+            });
+            res.end();
+            return;
+        }
+
         return readDirectory(filePath, baseUrl, (html: Error | string) => {
             if (html instanceof Error) {
                 res.writeHead(404, { 'Content-Type': 'text/html' });


### PR DESCRIPTION
Automatically append a trailing slash to folder names, otherwise the folder page URL lacks a slash separator.