### PR TITLE
chore(logger): Use a UTF-8 friendly separator.

### DIFF
--- a/packages/common/enums/logging.ts
+++ b/packages/common/enums/logging.ts
@@ -11,7 +11,7 @@ export const LogColor = {
 };
 
 export const LogSymbol = {
-    Separator: '▍',
+    Separator: '┃',
     ProgressBarFilled: '━',
     ProgressBarEmpty: '─'
 };


### PR DESCRIPTION
As reported on discord.
fixes the `unicode replacement character` problem.

problem:

<img width="1113" height="626" alt="image" src="https://github.com/user-attachments/assets/503a9f33-bdc2-4a7b-893c-4533ab432b3f" />
