### PR TITLE
fix: score offset

### DIFF
--- a/packages/tosu/src/memory/stable.ts
+++ b/packages/tosu/src/memory/stable.ts
@@ -553,7 +553,7 @@ export class StableMemory extends AbstractMemory<OsuPatternData> {
                 );
             // [[Ruleset + 0x68] + 0x38] + 0x64
             const mode = this.process.readInt(scoreBase + 0x64);
-            const score = this.process.readInt(rulesetAddr + 0xfc);
+            const score = this.process.readInt(rulesetAddr + 0x100);
             // [[Ruleset + 0x68] + 0x40] + 0x14
             const playerHPSmooth =
                 this.process.readDouble(hpBarBase + 0x14) || 0;


### PR DESCRIPTION
Cherrypick of 2c5484cc390ce9d69097aab57a73d6381dfdea6e