### PR TITLE
fix: incorrect pp due to wrong hit object counting, slider acc

### DIFF
--- a/packages/tosu/package.json
+++ b/packages/tosu/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@tosu/common": "workspace:*",
         "@tosu/ingame-overlay-updater": "workspace:*",
-        "@tosuapp/lazer-calculator": "0.2.0-20260610.0",
+        "@tosuapp/lazer-calculator": "0.4.0-20260610.0",
         "@tosu/server": "workspace:*",
         "@tosu/updater": "workspace:*",
         "osu-catch-stable": "^4.0.1",

--- a/packages/tosu/package.json
+++ b/packages/tosu/package.json
@@ -15,7 +15,7 @@
     "dependencies": {
         "@tosu/common": "workspace:*",
         "@tosu/ingame-overlay-updater": "workspace:*",
-        "@tosuapp/lazer-calculator": "0.4.0-20260610.0",
+        "@tosuapp/lazer-calculator": "0.4.0-20260616.0",
         "@tosu/server": "workspace:*",
         "@tosu/updater": "workspace:*",
         "osu-catch-stable": "^4.0.1",

--- a/packages/tosu/src/states/beatmap.ts
+++ b/packages/tosu/src/states/beatmap.ts
@@ -7,7 +7,6 @@ import {
     type PerformanceAttrsData,
     PlayBeatmap,
     type ScoreInfoData,
-    ScoreSimulator,
     type StrainsData
 } from '@tosuapp/lazer-calculator';
 import fs from 'fs';
@@ -418,7 +417,7 @@ export class BeatmapPP extends AbstractState {
             const difficulty = this.difficultyAttributes.getData();
 
             this.maxScore = {
-                ...ScoreSimulator.createScore(this.beatmap, 1.0),
+                ...this.beatmap.createScore(1.0),
                 maxCombo: difficulty.maxCombo
             };
 
@@ -438,10 +437,7 @@ export class BeatmapPP extends AbstractState {
                     const data = this.beatmap.calculatePerformance(
                         this.difficultyAttributes,
                         {
-                            ...ScoreSimulator.createScore(
-                                this.beatmap,
-                                acc / 100
-                            ),
+                            ...this.beatmap.createScore(acc / 100),
                             maxCombo: this.maxScore.maxCombo
                         }
                     );
@@ -786,11 +782,7 @@ export class BeatmapPP extends AbstractState {
             const curPerformance = this.beatmap.calculatePerformance(
                 diffAttrs,
                 {
-                    ...ScoreSimulator.createPartialScore(
-                        this.beatmap,
-                        passedObjects,
-                        1.0
-                    ),
+                    ...diffCalc.createProgressiveScore(1.0),
                     maxCombo: diffData.maxCombo
                 }
             );

--- a/packages/tosu/src/states/gameplay.ts
+++ b/packages/tosu/src/states/gameplay.ts
@@ -11,7 +11,7 @@ import {
     LeaderboardPlayer,
     Statistics
 } from '@/states/types';
-import { calculateGrade, calculatePassedObjects } from '@/utils/calculators';
+import { calculateGrade } from '@/utils/calculators';
 import { defaultCalculatedMods } from '@/utils/osuMods';
 import { CalculateMods, OsuMods } from '@/utils/osuMods.types';
 
@@ -90,7 +90,7 @@ export class Gameplay extends AbstractState {
     private cachedkeys: string = '';
 
     previousState: string = '';
-    previousPassedObjects = 0;
+    previousPlayTime = 0;
     previousHitErrorIndex = 0;
 
     constructor(game: AbstractInstance) {
@@ -137,7 +137,7 @@ export class Gameplay extends AbstractState {
         this.keyOverlay = [];
         this.isReplayUiHidden = false;
 
-        this.previousPassedObjects = 0;
+        this.previousPlayTime = 0;
         this.previousHitErrorIndex = 0;
 
         this.gradualPerformance = undefined;
@@ -162,7 +162,7 @@ export class Gameplay extends AbstractState {
             `Quick reset of gameplay state`
         );
 
-        this.previousPassedObjects = 0;
+        this.previousPlayTime = 0;
         this.gradualPerformance = undefined;
     }
 
@@ -500,24 +500,17 @@ export class Gameplay extends AbstractState {
                 this.previousState = currentState;
             }
 
-            const passedObjects = calculatePassedObjects(
-                beatmapPP.lazerBeatmap?.hitObjects || [],
-                global.playTime,
-                this.mode,
-                this.statistics
-            );
-
-            const offset = passedObjects - this.previousPassedObjects;
-            if (offset <= 0) {
-                if (offset === 0) return;
+            const timeOffset = global.playTime - this.previousPlayTime;
+            if (timeOffset <= 0) {
+                if (timeOffset === 0) return;
 
                 // Mostly for lazer replay, correct position on rewind
                 this.gradualPerformance =
                     currentBeatmap.createGradualDifficulty();
-                this.gradualPerformance.skip(passedObjects);
-            } else {
-                this.gradualPerformance.skip(offset);
             }
+
+            const offset = this.gradualPerformance.skipToTime(global.playTime);
+            if (offset === 0) return;
 
             const currDiffAttrs =
                 this.gradualPerformance.createDifficultyAttrs();
@@ -630,7 +623,7 @@ export class Gameplay extends AbstractState {
             beatmapPP.currAttributes.fcPP = fcPerformance.pp;
             beatmapPP.updatePPAttributes('fc', fcPerformance);
 
-            this.previousPassedObjects = passedObjects;
+            this.previousPlayTime = global.playTime;
 
             this.game.resetReportCount('gameplay updateStarsAndPerformance');
         } catch (exc) {

--- a/packages/tosu/src/states/gameplay.ts
+++ b/packages/tosu/src/states/gameplay.ts
@@ -1,6 +1,5 @@
 import { ClientType, config, measureTime, wLogger } from '@tosu/common';
 import {
-    AccuracyCalculator,
     GradualDifficulty,
     type ScoreInfoData
 } from '@tosuapp/lazer-calculator';
@@ -546,10 +545,8 @@ export class Gameplay extends AbstractState {
                 ignoreMisses: this.statistics.ignoreMiss
             };
             // Do not trust client accuracy for performance calculation, calculate it based on hit results
-            scoreInfo.accuracy = AccuracyCalculator.calculate(
-                currentBeatmap,
-                scoreInfo
-            );
+            scoreInfo.accuracy =
+                this.gradualPerformance.calculateProgressiveAccuracy(scoreInfo);
 
             const currPerformance = currentBeatmap.calculatePerformance(
                 currDiffAttrs,
@@ -599,10 +596,8 @@ export class Gameplay extends AbstractState {
                     this.statistics.miss;
                 calcOptions.greats = this.statistics.great;
             }
-            calcOptions.accuracy = AccuracyCalculator.calculate(
-                currentBeatmap,
-                calcOptions
-            );
+            calcOptions.accuracy =
+                currentBeatmap.calculateAccuracy(calcOptions);
 
             const maxAchievablePerformance =
                 currentBeatmap.calculatePerformance(
@@ -625,10 +620,8 @@ export class Gameplay extends AbstractState {
             calcOptions.sliderEndHits = beatmapPP.maxScore.sliderEndHits;
             calcOptions.comboBreaks = 0;
             calcOptions.misses = 0;
-            calcOptions.accuracy = AccuracyCalculator.calculate(
-                currentBeatmap,
-                calcOptions
-            );
+            calcOptions.accuracy =
+                currentBeatmap.calculateAccuracy(calcOptions);
 
             const fcPerformance = currentBeatmap.calculatePerformance(
                 beatmapPP.difficultyAttributes,

--- a/packages/tosu/src/states/resultScreen.ts
+++ b/packages/tosu/src/states/resultScreen.ts
@@ -1,8 +1,5 @@
 import { ClientType, measureTime, wLogger } from '@tosu/common';
-import {
-    AccuracyCalculator,
-    type ScoreInfoData
-} from '@tosuapp/lazer-calculator';
+import { type ScoreInfoData } from '@tosuapp/lazer-calculator';
 
 import { AbstractInstance } from '@/instances';
 import { AbstractState } from '@/states';
@@ -161,10 +158,8 @@ export class ResultScreen extends AbstractState {
                 misses: this.statistics.miss
             };
             // Do not trust client accuracy for performance calculation, calculate it based on hit results
-            calcOptions.accuracy = AccuracyCalculator.calculate(
-                currentBeatmap,
-                calcOptions
-            );
+            calcOptions.accuracy =
+                currentBeatmap.calculateAccuracy(calcOptions);
 
             const t1 = performance.now();
             const curPerformance = currentBeatmap.calculatePerformance(

--- a/packages/tosu/src/utils/calculators.ts
+++ b/packages/tosu/src/utils/calculators.ts
@@ -1,5 +1,3 @@
-import type { HitObject, IHasDuration } from 'osu-classes';
-
 import { Statistics } from '@/states/types';
 import { ModsLazer } from '@/utils/osuMods.types';
 
@@ -230,69 +228,3 @@ export const calculateGrade = (params: {
 
     return rank;
 };
-
-/**
- * Calculate passed objects based on time and statistics
- */
-export function calculatePassedObjects(
-    hitObjects: HitObject[],
-    time: number,
-    mode: number,
-    statistics: Statistics
-): number {
-    const passedObjects = passedObjectsFromStatistics(mode, statistics);
-
-    // Check if last object is actually ended
-    if (passedObjects > 0 && hitObjects[passedObjects - 1]) {
-        const lastHitObject = hitObjects[passedObjects - 1];
-
-        if ('endTime' in lastHitObject && 'duration' in lastHitObject) {
-            const endTime = (lastHitObject as IHasDuration).endTime;
-
-            if (endTime > time) {
-                return passedObjects - 1;
-            }
-        }
-    }
-
-    return passedObjects;
-}
-
-/**
- * Expect passed objects based on statistics
- */
-function passedObjectsFromStatistics(
-    mode: number,
-    statistics: Statistics
-): number {
-    switch (mode) {
-        case 0:
-            return (
-                statistics.great +
-                statistics.ok +
-                statistics.meh +
-                statistics.miss
-            );
-        case 1:
-            return statistics.great + statistics.ok + statistics.miss;
-        case 2:
-            return (
-                statistics.great +
-                statistics.good +
-                statistics.ok +
-                statistics.meh +
-                statistics.miss
-            );
-        case 3:
-            return (
-                statistics.great +
-                statistics.perfect +
-                statistics.ok +
-                statistics.good +
-                statistics.meh +
-                statistics.miss
-            );
-        default:
-            return 0;
-    }
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,7 +168,7 @@ importers:
         specifier: workspace:*
         version: link:../updater
       '@tosuapp/lazer-calculator':
-        specifier: v0.4.0-20260616.0
+        specifier: 0.4.0-20260616.0
         version: 0.4.0-20260616.0
       osu-catch-stable:
         specifier: ^4.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,8 +168,8 @@ importers:
         specifier: workspace:*
         version: link:../updater
       '@tosuapp/lazer-calculator':
-        specifier: 0.2.0-20260610.0
-        version: 0.2.0-20260610.0
+        specifier: v0.4.0-20260616.0
+        version: 0.4.0-20260616.0
       osu-catch-stable:
         specifier: ^4.0.1
         version: 4.0.1(osu-classes@3.1.0)
@@ -1048,8 +1048,8 @@ packages:
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
 
-  '@tosuapp/lazer-calculator@0.2.0-20260610.0':
-    resolution: {integrity: sha512-KwHU8C3Sv+vTW4GXBM7PGsddwy9rwrPg5HW8xiyNKJrUZ6W7P69GxRYejbQeeLXngkKvkXl0+CX391S06J2Nuw==}
+  '@tosuapp/lazer-calculator@0.4.0-20260616.0':
+    resolution: {integrity: sha512-8ua7me5lhoxll8rSoZu1k+GkDTYmKIJ5k5oyZN1Uk/7J7ujqdpz2+ZdAvXH0X7rsm7aussv+SWZPA+8N4PPjTg==}
 
   '@trivago/prettier-plugin-sort-imports@5.2.2':
     resolution: {integrity: sha512-fYDQA9e6yTNmA13TLVSA+WMQRc5Bn/c0EUBditUHNfMMxN7M82c38b1kEggVE3pLpZ0FwkwJkUEKMiOi52JXFA==}
@@ -5162,7 +5162,7 @@ snapshots:
 
   '@tootallnate/once@2.0.1': {}
 
-  '@tosuapp/lazer-calculator@0.2.0-20260610.0': {}
+  '@tosuapp/lazer-calculator@0.4.0-20260616.0': {}
 
   '@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.7.4)':
     dependencies:


### PR DESCRIPTION
* Replace incorrect hit object counting to time based. See https://discord.com/channels/1056534107330445362/1516026668198924439/1516094534248042627
* Fix incorrect accuracy calculation of beatmap subset. https://github.com/tosuapp/lazer-calculator/pull/6
* Update @tosuapp/lazer-calculator