### PR TITLE
fix: handle surface update error

### DIFF
--- a/packages/ingame-overlay/src/process.ts
+++ b/packages/ingame-overlay/src/process.ts
@@ -81,6 +81,10 @@ export class OverlayProcess {
             luid,
             window.webContents
         );
+
+        this.surface.events.on('error', (error: unknown) => {
+            console.error(error);
+        });
     }
 
     private openConfiguration() {
@@ -105,6 +109,7 @@ export class OverlayProcess {
             pid,
             5000
         );
+
         const [hwnd, width, height, luid] = await new Promise<
             [number, number, number, GpuLuid]
         >((resolve) =>


### PR DESCRIPTION
* overlay process dying by unhandled error due to changes introduced in #640, https://github.com/storycraft/asdf-overlay/pull/174