### PR TITLE
fix: remove redundant postinstall hook on tsprocess

### DIFF
--- a/packages/tsprocess/package.json
+++ b/packages/tsprocess/package.json
@@ -5,8 +5,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "prepare": "npm run build",
-    "build": "tsc",
-    "postinstall": "node-gyp clean configure build"
+    "build": "tsc"
   },
   "dependencies": {
     "node-addon-api": "^8.5.0",


### PR DESCRIPTION
Fixes #646

## Summary
`packages/tsprocess` ships a `binding.gyp`, so npm already runs `node-gyp rebuild` implicitly as part of `install`. The explicit `postinstall: node-gyp clean configure build` script duplicated that work, causing the native addon to build twice on every `npm install`.

## Changes
- Removed the redundant `postinstall` script from `packages/tsprocess/package.json`
- `prepare`/`build` scripts (TypeScript compile via `tsc`) are untouched and unaffected — they're separate from the native build

## Testing
- Ran a clean `npm install` in `packages/tsprocess` and confirmed the native module builds once instead of twice