### PR TITLE
fix: generateReportHTML now streams to avoid "Invalid String Length" being thrown

### DIFF
--- a/packages/server/assets/report.html
+++ b/packages/server/assets/report.html
@@ -249,6 +249,21 @@
     .status-warn {
       color: #dfdf53
     }
+
+    #truncation-banner {
+      display: none;
+      align-items: center;
+      gap: 0.6em;
+      padding: 0.6em 1em;
+      border-radius: 0.4em;
+      font-weight: 700;
+      color: var(--background-1);
+      background-color: #dfdf53;
+
+      span {
+        font-size: 1.2em;
+      }
+    }
   </style>
 </head>
 
@@ -261,6 +276,11 @@
 
     <!-- <button class="button export-button" onclick="exportJson()">Export to JSON</button> -->
   </header>
+
+  <div id="truncation-banner">
+    <span>&#9888;</span>
+    <p>These logs were truncated. The point at which they were truncated can be found within the logs below.</p>
+  </div>
 
   <main>
     <div class="group os-cfg">

--- a/packages/server/router/index.ts
+++ b/packages/server/router/index.ts
@@ -434,15 +434,13 @@ export default function buildBaseApi(server: Server) {
     });
 
     server.app.route('/api/generateReport', 'GET', async (req, res) => {
+        let report;
+        let iterator;
+        let first;
         try {
-            const report = await generateReport(req.instanceManager);
-            const html = await generateReportHTML(report);
-
-            res.writeHead(200, {
-                'Content-Type': 'text/html; charset=utf-8',
-                'Content-Disposition': `attachment; filename="${encodeURIComponent(`tosu-report-${report.date.getTime()}.html`)}"`
-            });
-            res.end(html, 'utf-8');
+            report = await generateReport(req.instanceManager);
+            iterator = generateReportHTML(report)[Symbol.asyncIterator]();
+            first = await iterator.next();
         } catch (err) {
             res.writeHead(500, {
                 'Content-Type': 'text/plain; charset=utf-8'
@@ -450,6 +448,22 @@ export default function buildBaseApi(server: Server) {
             res.end(
                 `Server Error: ${(err as Error).message || 'Unknown error'}`
             );
+            return;
+        }
+
+        res.writeHead(200, {
+            'Content-Type': 'text/html; charset=utf-8',
+            'Content-Disposition': `attachment; filename="${encodeURIComponent(`tosu-report-${report.date.getTime()}.html`)}"`
+        });
+
+        try {
+            for (; !first.done; first = await iterator.next()) {
+                res.write(first.value, 'utf-8');
+            }
+            res.end();
+        } catch (err) {
+            wLogger.error('Failed to stream report', (err as Error).message);
+            res.end();
         }
     });
 

--- a/packages/server/utils/report.ts
+++ b/packages/server/utils/report.ts
@@ -1,7 +1,8 @@
 import { Bitness, ClientType, config, context } from '@tosu/common';
-import { readFileSync, statSync } from 'node:fs';
+import { createReadStream, statSync } from 'node:fs';
 import { readFile, readdir } from 'node:fs/promises';
 import path from 'node:path';
+import { createInterface } from 'node:readline';
 import { battery, cpu, graphics, osInfo } from 'systeminformation';
 
 import { getLocalCounters } from './counters';
@@ -38,11 +39,9 @@ export type Report = {
         /** Counter folder name */
         folderName: string;
     }[];
-    /** Log file content */
-    logs: Array<[filename: string, LogLine[]]>;
+    /** Log files to include (read lazily while streaming the report) */
+    logs: { title: string; path: string }[];
 };
-
-type LogLine = [timestamp: string, type: string, text: string];
 
 async function specsDetails(): Promise<ReportSpecs> {
     const batt = await battery();
@@ -89,26 +88,10 @@ export async function generateReport(instanceManager: any): Promise<Report> {
             .map((fileName) => path.join(logsPath, fileName))
             .toSorted((a, b) => statSync(b).mtimeMs - statSync(a).mtimeMs)
             .slice(0, 10)
-            .map((filePath) => {
-                const log = readFileSync(filePath, 'utf8')
-                    .split('\n')
-                    .slice(0, -1)
-                    .map((r) => {
-                        const match = r.match(
-                            /^(\d{2}:\d{2}:\d{2}\.\d{3})\s+\[(.+?)\]\s+(.*)$/
-                        );
-
-                        if (match) {
-                            let level = match[2];
-                            if (level === 'derror') level = 'debugError';
-
-                            return [match[1], level, match[3]] as LogLine;
-                        }
-
-                        return ['', '', r] as LogLine;
-                    });
-                return [statSync(filePath).mtime.toISOString(), log];
-            })
+            .map((filePath) => ({
+                title: statSync(filePath).mtime.toISOString(),
+                path: filePath
+            }))
     };
 }
 
@@ -117,13 +100,7 @@ const pkgAssetsPath =
         ? path.join(__dirname, 'assets')
         : path.join(__dirname, '../assets');
 
-export async function generateReportHTML(report: Report): Promise<string> {
-    const rawHtml = await readFile(
-        path.join(pkgAssetsPath, 'report.html'),
-        'utf8'
-    );
-
-    const logHtml = `<div class="group logs">
+const LOG_GROUP_TEMPLATE = `<div class="group logs">
       <h3>{{TITLE}}</h3>
       <div class="group-content">
         <div class="scrollable">
@@ -142,21 +119,19 @@ export async function generateReportHTML(report: Report): Promise<string> {
       </div>
     </div>`;
 
-    const logs = report.logs.map((r) =>
-        logHtml
-            .replace('{{TITLE}}', r[0])
-            .replace(
-                '{{LOGS}}',
-                r[1]
-                    .map(
-                        (v, i) =>
-                            `<tr><td class="highlight">${i + 1}</td><td>${v[0]}</td><td class="status-${v[1]}">${v[1]}</td><td>${v[2]}</td></tr>`
-                    )
-                    .join('')
-            )
+const LOG_OUTPUT_BUDGET = 50 * 1024 * 1024;
+
+export async function* generateReportHTML(
+    report: Report
+): AsyncGenerator<string> {
+    const rawHtml = await readFile(
+        path.join(pkgAssetsPath, 'report.html'),
+        'utf8'
     );
 
-    return rawHtml
+    const [pageHead, pageTail] = rawHtml.split('{{LOGS}}');
+
+    yield pageHead
         .replace('{{TIME}}', report.date.toISOString())
         .replace('{{SYSTEM_TYPE}}', report.spec.systemType)
         .replace('{{SYSTEM_OS}}', report.spec.os)
@@ -188,6 +163,60 @@ export async function generateReportHTML(report: Report): Promise<string> {
                         `<tr><td class="highlight">${i + 1}</td><td>${v.name}</td><td>${v.version}</td><td>${v.author}</td><td>${v.folderName}</td></tr>`
                 )
                 .join('')
-        )
-        .replace('{{LOGS}}', logs.join(''));
+        );
+
+    const [logGroupHead, logGroupTail] = LOG_GROUP_TEMPLATE.split('{{LOGS}}');
+
+    let sent = 0;
+    let truncated = false;
+
+    for (const file of report.logs) {
+        yield logGroupHead.replace('{{TITLE}}', file.title);
+
+        const stream = createReadStream(file.path, 'utf8');
+        const rl = createInterface({ input: stream, crlfDelay: Infinity });
+        let i = 0;
+
+        try {
+            for await (const line of rl) {
+                const match = line.match(
+                    /^(\d{2}:\d{2}:\d{2}\.\d{3})\s+\[(.+?)\]\s+(.*)$/
+                );
+
+                let timestamp = '';
+                let level = '';
+                let text = line;
+                if (match) {
+                    timestamp = match[1];
+                    level = match[2] === 'derror' ? 'debugError' : match[2];
+                    text = match[3];
+                }
+
+                const row = `<tr><td class="highlight">${i + 1}</td><td>${timestamp}</td><td class="status-${level}">${level}</td><td>${text}</td></tr>`;
+                i++;
+
+                sent += Buffer.byteLength(row, 'utf8');
+                if (sent > LOG_OUTPUT_BUDGET) {
+                    truncated = true;
+                    yield `<tr><td class="highlight">…</td><td></td><td class="status-warn">warn</td><td>Log output truncated: report exceeded the ${LOG_OUTPUT_BUDGET / 1024 / 1024} MB budget.</td></tr>`;
+                    break;
+                }
+
+                yield row;
+            }
+        } finally {
+            rl.close();
+            stream.destroy();
+        }
+
+        yield logGroupTail;
+
+        if (truncated) break;
+    }
+
+    if (truncated) {
+        yield `<style>#truncation-banner { display: flex; }</style>`;
+    }
+
+    yield pageTail;
 }

--- a/packages/tosu/src/states/rankedplay.ts
+++ b/packages/tosu/src/states/rankedplay.ts
@@ -10,7 +10,7 @@ export class RankedPlay extends AbstractState {
     updateState() {
         try {
             const play = this.game.memory.rankedPlay();
-           this.info = play !== 'not-ready' ? play : undefined;
+            this.info = play !== 'not-ready' ? play : undefined;
         } catch (exc) {
             this.info = undefined;
 


### PR DESCRIPTION
changed so that the logs are read lazily line by line instead of being converted entirely into a single string, which can throw an error if either:
1) a single file is way too large
2) multiple large files are turned into strings and combined into a string that's too large

additionally, while this may be out of scope, i also decided to put a limit to how large the report.html can become by limiting how much information can be pulled from the logs. when the limit is reached, a warning banner is shown at the top telling you that the logs have been truncated for being too large, along with a cutoff line at the oldest log being retrieved before truncation to show where exactly the truncation happened. right now i put the limit at 50 mb, but it can be changed depending on how much of the logs is needed.

Closes #649 