### PR TITLE
feat: Move to Rolldown bundler + esmify codebase

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -2,6 +2,7 @@
   "name": "@tosu/common",
   "private": "true",
   "version": "0.0.1",
+  "type": "module",
   "description": "",
   "main": "index.ts",
   "scripts": {},

--- a/packages/common/utils/config.ts
+++ b/packages/common/utils/config.ts
@@ -4,7 +4,7 @@ import EventEmitter from 'node:events';
 import fs from 'node:fs/promises';
 import path from 'path';
 
-import {
+import type {
     ConfigBinding,
     ConfigEvents,
     ConfigItem,

--- a/packages/common/utils/directories.ts
+++ b/packages/common/utils/directories.ts
@@ -74,7 +74,6 @@ export function getCachePath() {
 }
 
 export function getProgramPath() {
-    if ('pkg' in process) return path.dirname(process.execPath);
     return process.cwd();
 }
 

--- a/packages/common/utils/directories.ts
+++ b/packages/common/utils/directories.ts
@@ -74,6 +74,7 @@ export function getCachePath() {
 }
 
 export function getProgramPath() {
+    if ('pkg' in process) return path.dirname(process.execPath);
     return process.cwd();
 }
 

--- a/packages/common/utils/downloader.ts
+++ b/packages/common/utils/downloader.ts
@@ -24,7 +24,7 @@ export const downloadFile = (
                 'User-Agent': '@tosuapp/tosu'
             },
             agent: new https.Agent({
-                secureOptions: require('node:crypto').constants.SSL_OP_ALL
+                secureOptions: crypto.constants.SSL_OP_ALL
             })
         };
 

--- a/packages/ingame-overlay-updater/package.json
+++ b/packages/ingame-overlay-updater/package.json
@@ -2,6 +2,7 @@
     "name": "@tosu/ingame-overlay-updater",
     "private": "true",
     "version": "0.0.1",
+    "type": "module",
     "main": "src/index.ts",
     "scripts": {},
     "dependencies": {

--- a/packages/ingame-overlay-updater/src/index.ts
+++ b/packages/ingame-overlay-updater/src/index.ts
@@ -8,7 +8,11 @@ import {
     verifyDownload,
     wLogger
 } from '@tosu/common';
-import { ChildProcess, ChildProcessByStdio, spawn } from 'node:child_process';
+import {
+    ChildProcess,
+    type ChildProcessByStdio,
+    spawn
+} from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { mkdir, rm } from 'node:fs/promises';
 import path from 'node:path';

--- a/packages/ingame-overlay/src/page.ts
+++ b/packages/ingame-overlay/src/page.ts
@@ -9,7 +9,7 @@ export async function loadMainPage(webContents: WebContents) {
         await webContents.loadURL(process.env.ELECTRON_RENDERER_URL);
     } else {
         await webContents.loadFile(
-            path.join(__dirname, '../renderer/index.html')
+            path.join(import.meta.dirname, '../renderer/index.html')
         );
     }
 }
@@ -17,4 +17,7 @@ export async function loadMainPage(webContents: WebContents) {
 /**
  * Path to preload script
  */
-export const preloadPath = path.join(__dirname, '../preload/index.js');
+export const preloadPath = path.join(
+    import.meta.dirname,
+    '../preload/index.js'
+);

--- a/packages/ingame-overlay/src/page.ts
+++ b/packages/ingame-overlay/src/page.ts
@@ -9,7 +9,7 @@ export async function loadMainPage(webContents: WebContents) {
         await webContents.loadURL(process.env.ELECTRON_RENDERER_URL);
     } else {
         await webContents.loadFile(
-            path.join(import.meta.dirname, '../renderer/index.html')
+            path.join(__dirname, '../renderer/index.html')
         );
     }
 }
@@ -17,7 +17,4 @@ export async function loadMainPage(webContents: WebContents) {
 /**
  * Path to preload script
  */
-export const preloadPath = path.join(
-    import.meta.dirname,
-    '../preload/index.js'
-);
+export const preloadPath = path.join(__dirname, '../preload/index.js');

--- a/packages/server/index.ts
+++ b/packages/server/index.ts
@@ -1,4 +1,4 @@
-import { GlobalConfig, config, wLogger } from '@tosu/common';
+import { type GlobalConfig, config, wLogger } from '@tosu/common';
 
 import buildAssetsApi from './router/assets';
 import buildBaseApi from './router/index';

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tosu/server",
   "version": "0.0.1",
+  "type": "module",
   "description": "",
   "author": "cyperdark",
   "main": "index.ts",

--- a/packages/server/router/assets.ts
+++ b/packages/server/router/assets.ts
@@ -4,10 +4,7 @@ import path from 'path';
 
 import { Server, getContentType } from '../index';
 
-const pkgAssetsPath =
-    'pkg' in process
-        ? path.join(__dirname, 'assets')
-        : path.join(__dirname, '../assets');
+const pkgAssetsPath = path.join(import.meta.dirname, 'assets');
 
 export default function buildAssetsApi(server: Server) {
     server.app.route(/^\/assets\/(?<filePath>.*)/, 'GET', (req, res) => {

--- a/packages/server/router/index.ts
+++ b/packages/server/router/index.ts
@@ -1,5 +1,5 @@
 import {
-    ConfigBinding,
+    type ConfigBinding,
     ConfigManager,
     JsonSafeParse,
     downloadFile,
@@ -26,15 +26,12 @@ import {
     getLocalCounters,
     saveSettings
 } from '../utils/counters';
-import { ISettings } from '../utils/counters.types';
+import { type ISettings } from '../utils/counters.types';
 import { directoryWalker } from '../utils/directories';
 import { parseCounterSettings } from '../utils/parseSettings';
 import { generateReport, generateReportHTML } from '../utils/report';
 
-const pkgAssetsPath =
-    'pkg' in process
-        ? path.join(__dirname, 'assets')
-        : path.join(__dirname, '../assets');
+const pkgAssetsPath = path.join(import.meta.dirname, 'assets');
 
 export default function buildBaseApi(server: Server) {
     server.app.route('/json', 'GET', (req, res) => {

--- a/packages/server/utils/commands.ts
+++ b/packages/server/utils/commands.ts
@@ -2,7 +2,7 @@ import { JsonSafeParse, debounce, wLogger } from '@tosu/common';
 
 import { getLocalCounters, saveSettings } from './counters';
 import { parseCounterSettings } from './parseSettings';
-import { ModifiedWebsocket, Websocket } from './socket';
+import { type ModifiedWebsocket, Websocket } from './socket';
 
 const saveDelay = debounce((overlayFrom: string, json: any) => {
     const html = saveSettings(overlayFrom, json);

--- a/packages/server/utils/counters.ts
+++ b/packages/server/utils/counters.ts
@@ -12,7 +12,7 @@ import path from 'path';
 import semver from 'semver';
 
 import { getContentType } from '../utils';
-import { ICounter, bodyPayload } from './counters.types';
+import type { ICounter, bodyPayload } from './counters.types';
 import {
     authorHTML,
     authorLinksHTML,
@@ -35,16 +35,7 @@ import {
 } from './htmls';
 import { parseCounterSettings } from './parseSettings';
 
-/**
- * ТАК КАК БЛЯТЬ У НАС В ЖЫЭСЕ
- * НЕ ПРИДУМАЛИ НОРМАЛЬНО ПАКЕТИРОВАТЬ ГОВНО БЕЗ ВЕБПАКА
- * ИДЕМ И ПИЛИМ КОСТЫЛИ
- * kys js!
- */
-const pkgAssetsPath =
-    'pkg' in process
-        ? path.join(__dirname, 'assets')
-        : path.join(__dirname, '../assets');
+const pkgAssetsPath = path.join(import.meta.dirname, 'assets');
 
 function splitTextByIndex(text: string, letter: string) {
     const index = text.indexOf(letter);

--- a/packages/server/utils/directories.ts
+++ b/packages/server/utils/directories.ts
@@ -1,10 +1,10 @@
 import { getStaticPath, wLogger } from '@tosu/common';
 import fs from 'fs';
 import http from 'http';
-import { OutgoingHttpHeaders } from 'http2';
+import type { OutgoingHttpHeaders } from 'http2';
 import path from 'path';
 
-import { ExtendedIncomingMessage, getContentType } from '../index';
+import { type ExtendedIncomingMessage, getContentType } from '../index';
 import { OVERLAYS_STATIC } from './homepage';
 
 const allowedRangeExtensions = [

--- a/packages/server/utils/parseSettings.ts
+++ b/packages/server/utils/parseSettings.ts
@@ -7,7 +7,11 @@ import {
 import fs from 'fs';
 import path from 'path';
 
-import { ISettings, ISettingsCompact, bodyPayload } from './counters.types';
+import type {
+    ISettings,
+    ISettingsCompact,
+    bodyPayload
+} from './counters.types';
 
 export function parseCounterSettings(
     folderName: string,

--- a/packages/server/utils/report.ts
+++ b/packages/server/utils/report.ts
@@ -112,10 +112,7 @@ export async function generateReport(instanceManager: any): Promise<Report> {
     };
 }
 
-const pkgAssetsPath =
-    'pkg' in process
-        ? path.join(__dirname, 'assets')
-        : path.join(__dirname, '../assets');
+const pkgAssetsPath = path.join(import.meta.dirname, 'assets');
 
 export async function generateReportHTML(report: Report): Promise<string> {
     const rawHtml = await readFile(

--- a/packages/server/utils/socket.ts
+++ b/packages/server/utils/socket.ts
@@ -1,5 +1,5 @@
-import { ConfigKey, config, sleep, wLogger } from '@tosu/common';
-import WebSocket from 'ws';
+import { type ConfigKey, config, sleep, wLogger } from '@tosu/common';
+import { WebSocket, WebSocketServer } from 'ws';
 
 import { getUniqueID } from './hashing';
 
@@ -30,7 +30,7 @@ export class Websocket {
 
     private onConnectionCallback: (id: string, url: string | undefined) => void;
 
-    socket: WebSocket.Server;
+    socket: WebSocketServer;
     clients = new Map<string, ModifiedWebsocket>();
 
     constructor({
@@ -54,7 +54,7 @@ export class Websocket {
         ) => void;
         onConnectionCallback?: (id: string, url: string | undefined) => void;
     }) {
-        this.socket = new WebSocket.Server({ noServer: true });
+        this.socket = new WebSocketServer({ noServer: true });
 
         this.instanceManager = instanceManager;
         this.pollRateFieldName = pollRateFieldName;

--- a/packages/tosu/package.json
+++ b/packages/tosu/package.json
@@ -1,13 +1,14 @@
 {
     "name": "tosu",
     "version": "4.24.0",
+    "type": "module",
     "main": "dist/index.js",
     "bin": "dist/index.js",
     "scripts": {
-        "genver": "npx genversion src/_version.js",
+        "genver": "npx genversion -es src/_version.js",
         "ts:run": "cross-env NODE_ENV=development tsx",
-        "ts:compile": "ncc build src/index.ts -o dist -m -d",
-        "run:dev": "pnpm run genver && pnpm run ts:run src/index.ts",
+        "ts:compile": "rolldown -c rolldown.config.mjs",
+        "run:dev": "pnpm run genver && pnpm run ts:compile && pnpm run compile:prepare-htmls && node --enable-source-maps dist/index.js",
         "compile:prepare-htmls": "cp -rf node_modules/@tosu/server/assets ./dist",
         "compile:win": "pnpm run genver && pnpm run ts:compile && pnpm run compile:prepare-htmls && pkg --output dist/tosu.exe --debug --config pkg.win.json --compress brotli dist/index.js && pnpm run ts:run src/postBuild.mts",
         "compile:linux": "pnpm run genver && pnpm run ts:compile && pnpm run compile:prepare-htmls && pkg --output dist/tosu --debug --config pkg.linux.json --compress brotli dist/index.js"
@@ -30,7 +31,7 @@
     },
     "devDependencies": {
         "@types/semver": "^7.7.1",
-        "@vercel/ncc": "^0.44.0",
+        "rolldown": "^1.1.5",
         "@yao-pkg/pkg": "^6.20.0",
         "cross-env": "^7.0.3",
         "genversion": "^3.2.0",

--- a/packages/tosu/pkg.linux.json
+++ b/packages/tosu/pkg.linux.json
@@ -1,14 +1,11 @@
 {
-    "scripts": "dist/**/*.js",
-    "assets": [
-      "dist/**/*.node",
-      "dist/**/*.wasm",
-      "dist/target/**/*",
-      "dist/_version.js",
-      "dist/assets/**/*"
-    ],
-    "targets": [
-	    "node24-linux-x64"
-    ],
-    "outputPath": "dist"
+  "assets": [
+    "dist/**/*.node",
+    "dist/**/*.wasm",
+    "dist/assets/**/*"
+  ],
+  "targets": [
+    "node24-linux-x64"
+  ],
+  "outputPath": "dist"
 }

--- a/packages/tosu/pkg.win.json
+++ b/packages/tosu/pkg.win.json
@@ -1,14 +1,11 @@
 {
-    "scripts": "dist/**/*.js",
-    "assets": [
-      "dist/**/*.node",
-      "dist/**/*.wasm",
-      "dist/target/**/*",
-      "dist/_version.js",
-      "dist/assets/**/*"
-    ],
-    "targets": [
-	"node24-win-x64"
-    ],
-    "outputPath": "dist"
-}   
+  "assets": [
+    "dist/**/*.node",
+    "dist/**/*.wasm",
+    "dist/assets/**/*"
+  ],
+  "targets": [
+    "node24-win-x64"
+  ],
+  "outputPath": "dist"
+}

--- a/packages/tosu/rolldown.config.mjs
+++ b/packages/tosu/rolldown.config.mjs
@@ -1,0 +1,59 @@
+// @ts-check
+import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { defineConfig } from 'rolldown';
+import { replacePlugin } from 'rolldown/plugins';
+
+export default defineConfig([
+    {
+        input: 'src/index.ts',
+        platform: 'node',
+        moduleTypes: {
+            '.node': 'copy'
+        },
+        output: {
+            minify: true,
+            keepNames: true,
+            sourcemap: true,
+            sourcemapExcludeSources: true,
+            format: 'esm',
+            dir: 'dist',
+            assetFileNames: '[name]-[hash][extname]'
+        },
+        plugins: [
+            rosuPlugin(),
+            replacePlugin({
+                __dirname: 'import.meta.dirname'
+            })
+        ]
+    }
+]);
+
+/**
+ * rosu wasm import fix
+ * @returns {import('rolldown').Plugin}
+ */
+function rosuPlugin() {
+    const rosuDir = path.dirname(
+        createRequire(import.meta.url).resolve('rosu-pp-js')
+    );
+
+    return {
+        name: 'rosu-wasm-fix',
+
+        buildStart() {
+            this.addWatchFile(path.join(rosuDir, 'rosu_pp_js_bg.wasm'));
+        },
+
+        async generateBundle() {
+            this.emitFile({
+                type: 'asset',
+                fileName: 'rosu_pp_js_bg.wasm',
+                source: await fs.readFile(
+                    path.join(rosuDir, 'rosu_pp_js_bg.wasm')
+                )
+            });
+        }
+    };
+}

--- a/packages/tosu/src/api/utils/buildResult.ts
+++ b/packages/tosu/src/api/utils/buildResult.ts
@@ -1,7 +1,7 @@
 import { ClientType, CountryCodes, GameState } from '@tosu/common';
 import path from 'path';
 
-import {
+import type {
     ApiAnswer,
     LeaderboardPlayer,
     TourneyIpcClient,
@@ -9,12 +9,12 @@ import {
 } from '@/api/types/v1';
 import { LazerInstance } from '@/instances/lazerInstance';
 import { InstanceManager } from '@/instances/manager';
-import { IUserProtected } from '@/memory/types';
-import { LeaderboardPlayer as MemoryLeaderboardPlayer } from '@/states/types';
+import type { IUserProtected } from '@/memory/types';
+import type { LeaderboardPlayer as MemoryLeaderboardPlayer } from '@/states/types';
 import { calculateGrade } from '@/utils/calculators';
 import { fixDecimals } from '@/utils/converters';
 import { toLegacyHits } from '@/utils/hitResult';
-import { CalculateMods } from '@/utils/osuMods.types';
+import type { CalculateMods } from '@/utils/osuMods.types';
 
 const convertMemoryPlayerToResult = (
     memoryPlayer: MemoryLeaderboardPlayer

--- a/packages/tosu/src/api/utils/buildResultSC.ts
+++ b/packages/tosu/src/api/utils/buildResultSC.ts
@@ -12,7 +12,7 @@ import { InstanceManager } from '@/instances/manager';
 import { fixDecimals } from '@/utils/converters';
 import { toLegacyHits } from '@/utils/hitResult';
 
-import { ApiAnswer } from '../types/sc';
+import type { ApiAnswer } from '../types/sc';
 
 export const buildResult = (instanceManager: InstanceManager): ApiAnswer => {
     const osuInstance = instanceManager.getInstance(

--- a/packages/tosu/src/api/utils/buildResultV2.ts
+++ b/packages/tosu/src/api/utils/buildResultV2.ts
@@ -19,7 +19,7 @@ import {
 } from '@tosu/common';
 import path from 'path';
 
-import {
+import type {
     ApiAnswer,
     Leaderboard,
     Play,
@@ -29,10 +29,10 @@ import {
 } from '@/api/types/v2';
 import { LazerInstance } from '@/instances/lazerInstance';
 import { InstanceManager } from '@/instances/manager';
-import { IUserProtected } from '@/memory/types';
+import type { IUserProtected } from '@/memory/types';
 import { BeatmapPP } from '@/states/beatmap';
 import { Gameplay } from '@/states/gameplay';
-import { LeaderboardPlayer as MemoryLeaderboardPlayer } from '@/states/types';
+import type { LeaderboardPlayer as MemoryLeaderboardPlayer } from '@/states/types';
 import { calculateGrade } from '@/utils/calculators';
 import { fixDecimals } from '@/utils/converters';
 import { toLegacyHits } from '@/utils/hitResult';

--- a/packages/tosu/src/api/utils/buildResultV2Precise.ts
+++ b/packages/tosu/src/api/utils/buildResultV2Precise.ts
@@ -1,4 +1,7 @@
-import { ApiAnswerPrecise as ApiAnswer, PreciseTourney } from '@/api/types/v2';
+import type {
+    ApiAnswerPrecise as ApiAnswer,
+    PreciseTourney
+} from '@/api/types/v2';
 import { InstanceManager } from '@/instances/manager';
 
 const buildTourneyData = (

--- a/packages/tosu/src/index.ts
+++ b/packages/tosu/src/index.ts
@@ -16,7 +16,7 @@ import { Process } from 'tsprocess';
 import { InstanceManager } from '@/instances/manager';
 
 // NOTE: _version.js packs with pkg support in tosu build
-const currentVersion = require('./_version.js');
+import { version as currentVersion } from './_version.js';
 
 (async () => {
     context.currentVersion = currentVersion;

--- a/packages/tosu/src/instances/manager.ts
+++ b/packages/tosu/src/instances/manager.ts
@@ -1,7 +1,7 @@
 import {
     ClientType,
-    GlobalConfig,
-    Platform,
+    type GlobalConfig,
+    type Platform,
     argumentsParser,
     checkGameOverlayConfig,
     config,
@@ -13,7 +13,7 @@ import { ChildProcess } from 'node:child_process';
 import { setTimeout } from 'node:timers/promises';
 import { Process } from 'tsprocess';
 
-import { AbstractInstance } from '@/instances';
+import type { AbstractInstance } from '@/instances';
 
 import { LazerInstance } from './lazerInstance';
 import { OsuInstance } from './osuInstance';

--- a/packages/tosu/src/memory/lazer.ts
+++ b/packages/tosu/src/memory/lazer.ts
@@ -45,7 +45,7 @@ import type {
     ScanPatterns
 } from '@/memory/types';
 import type { ITourneyManagerChatItem } from '@/states/tourney';
-import {
+import type {
     KeyOverlayButton,
     LeaderboardPlayer,
     Statistics
@@ -56,14 +56,14 @@ import {
     numberFromDecimal
 } from '@/utils/converters';
 import {
-    MultiplayerTeamType,
+    type MultiplayerTeamType,
     MultiplayerUserState
 } from '@/utils/multiplayer.types';
 import { calculateMods, defaultCalculatedMods } from '@/utils/osuMods';
 import {
-    CalculateMods,
-    Mod,
-    ModsAcronyms,
+    type CalculateMods,
+    type Mod,
+    type ModsAcronyms,
     ModsCategories
 } from '@/utils/osuMods.types';
 

--- a/packages/tosu/src/memory/stable.ts
+++ b/packages/tosu/src/memory/stable.ts
@@ -7,7 +7,7 @@ import {
 } from '@tosu/common';
 import { getContentType } from '@tosu/server';
 
-import { OsuVersion } from '@/instances';
+import { type OsuVersion } from '@/instances';
 import { AbstractMemory } from '@/memory';
 import type {
     IAudioVelocityBase,
@@ -33,7 +33,7 @@ import type {
 } from '@/memory/types';
 import { defaultStatistics } from '@/states/gameplay';
 import type { ITourneyManagerChatItem } from '@/states/tourney';
-import { LeaderboardPlayer } from '@/states/types';
+import type { LeaderboardPlayer } from '@/states/types';
 import { Bindings, VirtualKeyCode } from '@/utils/bindings';
 import { calculateAccuracy } from '@/utils/calculators';
 import { netDateBinaryToDate } from '@/utils/converters';

--- a/packages/tosu/src/states/beatmap.ts
+++ b/packages/tosu/src/states/beatmap.ts
@@ -13,12 +13,12 @@ import fs from 'fs';
 import { Beatmap as ParsedBeatmap, TimingPoint } from 'osu-classes';
 import { BeatmapDecoder } from 'osu-parsers';
 
-import { BeatmapStrains } from '@/api/types/v1';
+import type { BeatmapStrains } from '@/api/types/v1';
 import { AbstractInstance } from '@/instances';
 import { AbstractState } from '@/states';
 import { fixDecimals, safeJoin } from '@/utils/converters';
 import { sanitizeMods } from '@/utils/osuMods';
-import { CalculateMods } from '@/utils/osuMods.types';
+import type { CalculateMods } from '@/utils/osuMods.types';
 
 interface BeatmapPPAcc {
     '100': number;

--- a/packages/tosu/src/states/gameplay.ts
+++ b/packages/tosu/src/states/gameplay.ts
@@ -6,14 +6,14 @@ import {
 
 import { AbstractInstance } from '@/instances';
 import { AbstractState } from '@/states/index';
-import {
+import type {
     KeyOverlayButton,
     LeaderboardPlayer,
     Statistics
 } from '@/states/types';
 import { calculateGrade } from '@/utils/calculators';
 import { defaultCalculatedMods } from '@/utils/osuMods';
-import { CalculateMods, OsuMods } from '@/utils/osuMods.types';
+import { type CalculateMods, OsuMods } from '@/utils/osuMods.types';
 
 export const defaultStatistics = {
     miss: 0,

--- a/packages/tosu/src/states/global.ts
+++ b/packages/tosu/src/states/global.ts
@@ -3,7 +3,7 @@ import { ClientType, measureTime, wLogger } from '@tosu/common';
 import { AbstractState } from '@/states';
 import { safeJoin } from '@/utils/converters';
 import { defaultCalculatedMods } from '@/utils/osuMods';
-import { CalculateMods } from '@/utils/osuMods.types';
+import type { CalculateMods } from '@/utils/osuMods.types';
 
 export class Global extends AbstractState {
     isWatchingReplay: boolean = false;

--- a/packages/tosu/src/states/lazerMultiSpectating.ts
+++ b/packages/tosu/src/states/lazerMultiSpectating.ts
@@ -1,7 +1,7 @@
 import { ClientType, measureTime, wLogger } from '@tosu/common';
 
 import { type LazerInstance } from '@/instances/lazerInstance';
-import { ILazerSpectator } from '@/memory/types';
+import type { ILazerSpectator } from '@/memory/types';
 import { AbstractState } from '@/states';
 
 export class LazerMultiSpectating extends AbstractState {

--- a/packages/tosu/src/states/rankedplay.ts
+++ b/packages/tosu/src/states/rankedplay.ts
@@ -1,6 +1,6 @@
 import { ClientType, measureTime, wLogger } from '@tosu/common';
 
-import { IRankedPlay } from '@/memory/types';
+import type { IRankedPlay } from '@/memory/types';
 import { AbstractState } from '@/states/index';
 
 export class RankedPlay extends AbstractState {

--- a/packages/tosu/src/states/resultScreen.ts
+++ b/packages/tosu/src/states/resultScreen.ts
@@ -5,10 +5,10 @@ import { AbstractInstance } from '@/instances';
 import { AbstractState } from '@/states';
 import { calculateGrade } from '@/utils/calculators';
 import { defaultCalculatedMods } from '@/utils/osuMods';
-import { CalculateMods } from '@/utils/osuMods.types';
+import type { CalculateMods } from '@/utils/osuMods.types';
 
 import { defaultStatistics } from './gameplay';
-import { Statistics } from './types';
+import type { Statistics } from './types';
 
 export class ResultScreen extends AbstractState {
     onlineId: number;

--- a/packages/tosu/src/states/types.ts
+++ b/packages/tosu/src/states/types.ts
@@ -1,4 +1,4 @@
-import { CalculateMods } from '@/utils/osuMods.types';
+import type { CalculateMods } from '@/utils/osuMods.types';
 
 export interface Statistics {
     perfect: number;

--- a/packages/tosu/src/states/user.ts
+++ b/packages/tosu/src/states/user.ts
@@ -1,6 +1,6 @@
 import { ClientType, measureTime, wLogger } from '@tosu/common';
 
-import { IMatchmakingStats } from '@/memory/types';
+import type { IMatchmakingStats } from '@/memory/types';
 import { AbstractState } from '@/states';
 
 export class User extends AbstractState {

--- a/packages/tosu/src/utils/calculators.ts
+++ b/packages/tosu/src/utils/calculators.ts
@@ -1,5 +1,5 @@
-import { Statistics } from '@/states/types';
-import { ModsLazer } from '@/utils/osuMods.types';
+import { type Statistics } from '@/states/types';
+import { type ModsLazer } from '@/utils/osuMods.types';
 
 /**
  * Used to calculate accuracy out of hits

--- a/packages/tosu/src/utils/osuMods.ts
+++ b/packages/tosu/src/utils/osuMods.ts
@@ -1,9 +1,9 @@
 import { textMD5 } from '@tosu/common';
 
 import {
-    CalculateMods,
-    IMods,
-    ModsLazer,
+    type CalculateMods,
+    type IMods,
+    type ModsLazer,
     ModsOrder,
     bitValues
 } from '@/utils/osuMods.types';

--- a/packages/tsprocess/package.json
+++ b/packages/tsprocess/package.json
@@ -1,6 +1,7 @@
 {
   "name": "tsprocess",
   "version": "1.0.1",
+  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/tsprocess/src/index.ts
+++ b/packages/tsprocess/src/index.ts
@@ -1,6 +1,2 @@
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-
 export default require('./lib/tsprocess.node');
 export * from './process';

--- a/packages/tsprocess/src/index.ts
+++ b/packages/tsprocess/src/index.ts
@@ -1,2 +1,6 @@
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
 export default require('./lib/tsprocess.node');
 export * from './process';

--- a/packages/updater/package.json
+++ b/packages/updater/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tosu/updater",
   "version": "0.0.1",
+  "type": "module",
   "description": "",
   "author": "cyperdark",
   "main": "index.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,12 +198,12 @@ importers:
         specifier: workspace:*
         version: link:../tsprocess
     devDependencies:
+      '@rollup/plugin-commonjs':
+        specifier: ^29.0.3
+        version: 29.0.3(rollup@4.54.0)
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
-      '@vercel/ncc':
-        specifier: ^0.44.0
-        version: 0.44.0
       '@yao-pkg/pkg':
         specifier: ^6.20.0
         version: 6.20.0(encoding@0.1.13)
@@ -213,6 +213,9 @@ importers:
       genversion:
         specifier: ^3.2.0
         version: 3.2.0
+      rolldown:
+        specifier: ^1.1.5
+        version: 1.1.5
       tsx:
         specifier: ^4.23.0
         version: 4.23.0
@@ -399,6 +402,15 @@ packages:
     resolution: {integrity: sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==}
     engines: {node: '>=14.14'}
     hasBin: true
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -1123,6 +1135,12 @@ packages:
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
     engines: {node: '>= 16'}
@@ -1139,6 +1157,9 @@ packages:
     resolution: {integrity: sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This functionality has been moved to @npmcli/fs
+
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
 
   '@parcel/watcher-android-arm64@2.5.1':
     resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
@@ -1247,6 +1268,116 @@ packages:
   '@roberts_lando/vfs@0.3.3':
     resolution: {integrity: sha512-YjkxVSLw5WMZQoARaryRAjcxA+GbBzWMJdwYZX5oLUt9cC/gew9as4Dn7tcLzPp7BPoR221VpTZ+78TRPawnjg==}
     engines: {node: '>= 22'}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@rollup/plugin-commonjs@29.0.3':
+    resolution: {integrity: sha512-ZaOxZceP7SOUW7Lqw5IRVweSQYWaeIPnXIGLiB690EBA3FGJTO40EEr2L5yZplJWsgTCogILRSpcAe7+U0Otdg==}
+    engines: {node: '>=16.0.0 || 14 >= 14.17'}
+    peerDependencies:
+      rollup: ^2.68.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.54.0':
     resolution: {integrity: sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==}
@@ -1403,6 +1534,9 @@ packages:
       svelte:
         optional: true
 
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
   '@types/adm-zip@0.5.7':
     resolution: {integrity: sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==}
 
@@ -1518,10 +1652,6 @@ packages:
   '@typescript-eslint/visitor-keys@8.63.0':
     resolution: {integrity: sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@vercel/ncc@0.44.0':
-    resolution: {integrity: sha512-pHyI+bZokSgIscTKFSmpNk5vZzmOrb9RW0Vu4SRyqUvkJ0kgg3PzaZLLDVTFXhbUiCqg0/Eu8L4fKtgViA92kg==}
-    hasBin: true
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
@@ -1988,6 +2118,9 @@ packages:
   commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
+
+  commondir@1.0.1:
+    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
@@ -2494,6 +2627,9 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -3017,6 +3153,9 @@ packages:
   is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
+
+  is-reference@1.2.1:
+    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -3964,6 +4103,11 @@ packages:
   roarr@2.15.4:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
+
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   rollup@4.54.0:
     resolution: {integrity: sha512-3nk8Y3a9Ea8szgKhinMlGMhGMw89mqule3KWczxhIzqudyHdCIOHw8WJlj/r329fACjKLEh13ZSk7oE22kyeIw==}
@@ -4917,6 +5061,22 @@ snapshots:
       - supports-color
     optional: true
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
@@ -5340,6 +5500,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@noble/hashes@1.4.0': {}
 
   '@noble/hashes@2.2.0': {}
@@ -5353,6 +5520,8 @@ snapshots:
     dependencies:
       mkdirp: 1.0.4
       rimraf: 3.0.2
+
+  '@oxc-project/types@0.139.0': {}
 
   '@parcel/watcher-android-arm64@2.5.1':
     optional: true
@@ -5443,6 +5612,77 @@ snapshots:
   '@pkgr/core@0.2.9': {}
 
   '@roberts_lando/vfs@0.3.3': {}
+
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@rollup/plugin-commonjs@29.0.3(rollup@4.54.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.4.0(rollup@4.54.0)
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      fdir: 6.5.0(picomatch@4.0.3)
+      is-reference: 1.2.1
+      magic-string: 0.30.21
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.54.0
+
+  '@rollup/pluginutils@5.4.0(rollup@4.54.0)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.54.0
 
   '@rollup/rollup-android-arm-eabi@4.54.0':
     optional: true
@@ -5542,6 +5782,11 @@ snapshots:
       prettier: 3.7.4
     transitivePeerDependencies:
       - supports-color
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/adm-zip@0.5.7':
     dependencies:
@@ -5697,8 +5942,6 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.63.0
       eslint-visitor-keys: 5.0.1
-
-  '@vercel/ncc@0.44.0': {}
 
   '@xmldom/xmldom@0.8.11': {}
 
@@ -6328,6 +6571,8 @@ snapshots:
   commander@7.2.0: {}
 
   commander@9.5.0: {}
+
+  commondir@1.0.1: {}
 
   compare-func@2.0.0:
     dependencies:
@@ -7099,6 +7344,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@2.0.2: {}
+
   esutils@2.0.3: {}
 
   eventemitter3@5.0.1: {}
@@ -7654,6 +7901,10 @@ snapshots:
   is-obj@2.0.0: {}
 
   is-plain-obj@1.1.0: {}
+
+  is-reference@1.2.1:
+    dependencies:
+      '@types/estree': 1.0.8
 
   is-regex@1.2.1:
     dependencies:
@@ -8603,6 +8854,27 @@ snapshots:
       semver-compare: 1.0.0
       sprintf-js: 1.1.3
     optional: true
+
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
 
   rollup@4.54.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,9 +198,6 @@ importers:
         specifier: workspace:*
         version: link:../tsprocess
     devDependencies:
-      '@rollup/plugin-commonjs':
-        specifier: ^29.0.3
-        version: 29.0.3(rollup@4.54.0)
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
@@ -1361,24 +1358,6 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
-  '@rollup/plugin-commonjs@29.0.3':
-    resolution: {integrity: sha512-ZaOxZceP7SOUW7Lqw5IRVweSQYWaeIPnXIGLiB690EBA3FGJTO40EEr2L5yZplJWsgTCogILRSpcAe7+U0Otdg==}
-    engines: {node: '>=16.0.0 || 14 >= 14.17'}
-    peerDependencies:
-      rollup: ^2.68.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
-  '@rollup/pluginutils@5.4.0':
-    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-
   '@rollup/rollup-android-arm-eabi@4.54.0':
     resolution: {integrity: sha512-OywsdRHrFvCdvsewAInDKCNyR3laPA2mc9bRYJ6LBp5IyvF3fvXbbNR0bSzHlZVFtn6E0xw2oZlyjg4rKCVcng==}
     cpu: [arm]
@@ -2119,9 +2098,6 @@ packages:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
 
-  commondir@1.0.1:
-    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
-
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
 
@@ -2627,9 +2603,6 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
-
-  estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -3153,9 +3126,6 @@ packages:
   is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
-
-  is-reference@1.2.1:
-    resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -5664,26 +5634,6 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/plugin-commonjs@29.0.3(rollup@4.54.0)':
-    dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.54.0)
-      commondir: 1.0.1
-      estree-walker: 2.0.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      is-reference: 1.2.1
-      magic-string: 0.30.21
-      picomatch: 4.0.3
-    optionalDependencies:
-      rollup: 4.54.0
-
-  '@rollup/pluginutils@5.4.0(rollup@4.54.0)':
-    dependencies:
-      '@types/estree': 1.0.8
-      estree-walker: 2.0.2
-      picomatch: 4.0.3
-    optionalDependencies:
-      rollup: 4.54.0
-
   '@rollup/rollup-android-arm-eabi@4.54.0':
     optional: true
 
@@ -6572,8 +6522,6 @@ snapshots:
 
   commander@9.5.0: {}
 
-  commondir@1.0.1: {}
-
   compare-func@2.0.0:
     dependencies:
       array-ify: 1.0.0
@@ -7344,8 +7292,6 @@ snapshots:
 
   estraverse@5.3.0: {}
 
-  estree-walker@2.0.2: {}
-
   esutils@2.0.3: {}
 
   eventemitter3@5.0.1: {}
@@ -7901,10 +7847,6 @@ snapshots:
   is-obj@2.0.0: {}
 
   is-plain-obj@1.1.0: {}
-
-  is-reference@1.2.1:
-    dependencies:
-      '@types/estree': 1.0.8
 
   is-regex@1.2.1:
     dependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,13 +5,15 @@
     ],
     "target": "es2023",
     "ignoreDeprecations": "6.0",
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "module": "preserve",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
+    "isolatedModules": true,
     "noImplicitAny": true,
     "sourceMap": false,
     "declaration": false,
     "noEmit": true,
     "strict": true,
+    "verbatimModuleSyntax": true
   }
 }


### PR DESCRIPTION
1. Switched tsconfig module resolution to bundler.
2. Replaced ncc to rolldown
3. All workspace packages are now native esm(`"type": "module"`).
4. Effectively removing all differences between dev and prod environment. It runs on bundled file + source map to match with production env. Resolving pkgAssetsPath hack and allows to use bundler post processing stuffs.

* Blocked by #651. Do not merge it before that pr.