### PR TITLE
Resolve outdated static folder path creation and default to local share on Linux

### DIFF
--- a/packages/common/utils/config.ts
+++ b/packages/common/utils/config.ts
@@ -2,6 +2,7 @@ import { createHash } from 'crypto';
 import * as dotenv from 'dotenv';
 import EventEmitter from 'node:events';
 import fs from 'node:fs/promises';
+import { homedir } from 'node:os';
 import path from 'path';
 
 import type {
@@ -65,7 +66,12 @@ const defaultSchema: ConfigSchema = {
     },
     staticFolderPath: {
         binding: 'STATIC_FOLDER_PATH',
-        default: './static'
+        default:
+            process.platform === 'linux'
+                ? process.env.XDG_DATA_HOME
+                    ? path.join(process.env.XDG_DATA_HOME, 'tosu', 'static')
+                    : path.join(homedir(), '.local', 'share', 'tosu', 'static')
+                : './static'
     },
     enableIngameOverlay: {
         binding: 'ENABLE_INGAME_OVERLAY',

--- a/packages/common/utils/config.ts
+++ b/packages/common/utils/config.ts
@@ -12,7 +12,7 @@ import type {
     ConfigSchema,
     GlobalConfig
 } from './config.types';
-import { getConfigPath } from './directories';
+import { getConfigPath, getStaticPath } from './directories';
 import { wLogger } from './logger';
 import { isRealNumber } from './manipulation';
 
@@ -492,5 +492,5 @@ export async function configInitialization() {
     await ConfigManager.initialize(configPath);
 
     // Create user-specified static folder
-    await fs.mkdir(config.staticFolderPath, { recursive: true }).catch(null);
+    await fs.mkdir(getStaticPath(), { recursive: true }).catch(null);
 }

--- a/packages/common/utils/config.ts
+++ b/packages/common/utils/config.ts
@@ -2,7 +2,6 @@ import { createHash } from 'crypto';
 import * as dotenv from 'dotenv';
 import EventEmitter from 'node:events';
 import fs from 'node:fs/promises';
-import { homedir } from 'node:os';
 import path from 'path';
 
 import type {
@@ -13,7 +12,7 @@ import type {
     ConfigSchema,
     GlobalConfig
 } from './config.types';
-import { getConfigPath, getStaticPath } from './directories';
+import { getConfigPath, getDataPath, getStaticPath } from './directories';
 import { wLogger } from './logger';
 import { isRealNumber } from './manipulation';
 
@@ -68,9 +67,7 @@ const defaultSchema: ConfigSchema = {
         binding: 'STATIC_FOLDER_PATH',
         default:
             process.platform === 'linux'
-                ? process.env.XDG_DATA_HOME
-                    ? path.join(process.env.XDG_DATA_HOME, 'tosu', 'static')
-                    : path.join(homedir(), '.local', 'share', 'tosu', 'static')
+                ? path.join(getDataPath(), 'static')
                 : './static'
     },
     enableIngameOverlay: {


### PR DESCRIPTION
Reported on discord at https://discord.com/channels/1056534107330445362/1527660136154267800

I also changed the env default to the linux path, because imo it's kind of absurd to have `./static` in the .env but find the static folder at `~/.local/share/tosu/static`

Fallback for `./static` on linux still remains, as I am not willing to do config migration for this little inconvenience.