### PR TITLE
ci: bump actions to support node 24 runtime

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
     name: "build for ${{ matrix.os }}"
     steps:
       - name: 🛎️ - Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: 📐 - Define variables (1)
         if: github.event_name == 'pull_request'
@@ -43,7 +43,7 @@ jobs:
         run: echo "SHORT_PR_SHA=$(git rev-parse HEAD | cut -c 1-7)" >> "$GITHUB_OUTPUT"
 
       - name: 🛠️ - Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with: { node-version: 24.14.0 }
 
       - name: 🛠️ - Install Deps
@@ -69,7 +69,7 @@ jobs:
       - name: 🚀 - Upload artifacts for windows
         id: upload-artifact-windows
         if: ${{ matrix.os == 'windows-latest' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: {
           name: "tosu-windows-${{ steps.set-pr-sha.outputs.SHORT_PR_SHA || github.ref_name }}",
           path: packages/tosu/dist/tosu.exe
@@ -77,7 +77,7 @@ jobs:
       
       - name: 🚀 - Upload overlay artifacts for windows
         if: ${{ matrix.os == 'windows-latest' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: {
           name: "tosu-overlay-${{ steps.set-pr-sha.outputs.SHORT_PR_SHA || github.ref_name }}",
           path: packages/ingame-overlay/pack/win-unpacked/*
@@ -85,7 +85,7 @@ jobs:
 
       - name: 🚀 - Upload artifacts for linux
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with: {
           name: "tosu-linux-${{ steps.set-pr-sha.outputs.SHORT_PR_SHA || github.ref_name }}",
           path: packages/tosu/dist/tosu

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ on:
       - "pnpm-lock.yaml"
   pull_request:
     paths:
+      - ".github/workflows/**/*"
       - "packages/**/*"
       - "package.json"
       - "pnpm-lock.yaml"

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -13,10 +13,10 @@ jobs:
     #runs-on: windows-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Install Node.js 🔧
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v7
         with:
           node-version: 24.14.0
 


### PR DESCRIPTION
Fixes node 20 deprecation warnings in actions tab, hopefully.
Updated `actions/checkout`, `actions/setup-node` and `actions/upload-artifact` to latest version. (`v7`)

> [!WARNING]
>  As of `actions/setup-node@v5`, caching is by default enabled for `node_modules`.

<img width="1056" height="267" alt="Screenshot 2026-07-17 164530" src="https://github.com/user-attachments/assets/c53e1c5a-2468-4c95-bd66-4892a78e4d36" />