### PR TITLE
refactor: max achievable, fc score calculation logic

### DIFF
--- a/packages/tosu/package.json
+++ b/packages/tosu/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "@tosu/common": "workspace:*",
         "@tosu/ingame-overlay-updater": "workspace:*",
-        "@tosuapp/lazer-calculator-prebuilt": "0.5.0-20260715-main.0",
+        "@tosuapp/lazer-calculator-prebuilt": "0.5.1-20260718-main.0",
         "@tosu/server": "workspace:*",
         "@tosu/updater": "workspace:*",
         "osu-catch-stable": "^4.0.1",

--- a/packages/tosu/package.json
+++ b/packages/tosu/package.json
@@ -16,7 +16,7 @@
     "dependencies": {
         "@tosu/common": "workspace:*",
         "@tosu/ingame-overlay-updater": "workspace:*",
-        "@tosuapp/lazer-calculator-prebuilt": "0.5.1-20260718-main.0",
+        "@tosuapp/lazer-calculator-prebuilt": "0.6.0-20260726-main.0",
         "@tosu/server": "workspace:*",
         "@tosu/updater": "workspace:*",
         "osu-catch-stable": "^4.0.1",

--- a/packages/tosu/src/states/beatmap.ts
+++ b/packages/tosu/src/states/beatmap.ts
@@ -396,12 +396,12 @@ export class BeatmapPP extends AbstractState {
                     settings:
                         'settings' in mod && mod.settings
                             ? new Map(Object.entries(mod.settings))
-                            : undefined
+                            : new Map()
                 })
             );
             if (this.game.client !== ClientType.lazer) {
                 // Add classic mod if client is not on lazer.
-                mods.push({ acronym: 'CL' });
+                mods.push({ acronym: 'CL', settings: new Map() });
             }
             this.beatmap.applyMods(mods);
 

--- a/packages/tosu/src/states/beatmap.ts
+++ b/packages/tosu/src/states/beatmap.ts
@@ -1,8 +1,8 @@
 import { ClientType, config, measureTime, wLogger } from '@tosu/common';
 import {
     type DifficultyAttrs,
-    HitWindows,
     type LazerMod,
+    OsuHitResult,
     type PeakStrains,
     type PerformanceAttrsData,
     PlayBeatmap,
@@ -391,19 +391,17 @@ export class BeatmapPP extends AbstractState {
             );
 
             const mods: LazerMod[] = sanitizeMods(currentMods.array).map(
-                (mod) => {
-                    return {
-                        acronym: mod.acronym,
-                        settings:
-                            'settings' in mod && mod.settings
-                                ? new Map(Object.entries(mod.settings))
-                                : new Map()
-                    };
-                }
+                (mod) => ({
+                    acronym: mod.acronym,
+                    settings:
+                        'settings' in mod && mod.settings
+                            ? new Map(Object.entries(mod.settings))
+                            : undefined
+                })
             );
             if (this.game.client !== ClientType.lazer) {
                 // Add classic mod if client is not on lazer.
-                mods.push({ acronym: 'CL', settings: new Map() });
+                mods.push({ acronym: 'CL' });
             }
             this.beatmap.applyMods(mods);
 
@@ -546,6 +544,8 @@ export class BeatmapPP extends AbstractState {
             const originalDifficulty =
                 this.beatmap.getOriginalBeatmapDifficulty();
             const convertedDifficulty = this.beatmap.getBeatmapDifficulty();
+
+            const hitWindows = this.beatmap.createHitWindows();
             this.calculatedMapAttributes = {
                 ar: originalDifficulty.approachRate,
                 arConverted: convertedDifficulty.approachRate,
@@ -570,10 +570,8 @@ export class BeatmapPP extends AbstractState {
                 rhythm: difficulty.rhythm,
                 color: difficulty.color,
                 reading: difficulty.reading,
-                hitWindow: HitWindows.getGreatHitWindow(
-                    this.beatmap.mode,
-                    convertedDifficulty.overallDifficulty
-                )
+                hitWindow:
+                    hitWindows.windowFor(OsuHitResult.Great) / this.clockRate
             };
 
             this.game.resetReportCount('beatmapPP updateMapMetadata');

--- a/packages/tosu/src/states/gameplay.ts
+++ b/packages/tosu/src/states/gameplay.ts
@@ -14,6 +14,7 @@ import type {
 import { calculateGrade } from '@/utils/calculators';
 import { defaultCalculatedMods } from '@/utils/osuMods';
 import { type CalculateMods, OsuMods } from '@/utils/osuMods.types';
+import { calculateFcScore, calculateMaxAchievableScore } from '@/utils/score';
 
 export const defaultStatistics = {
     miss: 0,
@@ -554,71 +555,29 @@ export class Gameplay extends AbstractState {
 
             beatmapPP.updatePPAttributes('curr', currPerformance);
 
-            const calcOptions: ScoreInfoData = {
-                ...scoreInfo,
-                // Calculate max archivable combo based difference between gradual and current combo
-                maxCombo: Math.max(
-                    this.maxCombo,
-                    beatmapPP.maxScore.maxCombo -
-                        (currDiff.maxCombo - this.combo)
-                ),
-                greats:
-                    beatmapPP.maxScore.greats -
-                    this.statistics.ok -
-                    this.statistics.meh -
-                    this.statistics.miss,
-                largeTickHits:
-                    beatmapPP.maxScore.largeTickHits -
-                    this.statistics.largeTickMiss,
-                // Calculate max archivable slider end hits based difference between gradual and current hits
-                sliderEndHits:
-                    beatmapPP.maxScore.sliderEndHits -
-                    (currDiff.nSliders - this.statistics.sliderTailHit),
-                // Small hit ticks doesn't affect combo but only accuracy.
-                smallTickHits:
-                    beatmapPP.maxScore.smallTickHits -
-                    this.statistics.smallTickMiss
-            };
-
-            if (this.mode === 3) {
-                calcOptions.perfects =
-                    beatmapPP.maxScore.perfects -
-                    this.statistics.good -
-                    this.statistics.ok -
-                    this.statistics.meh -
-                    this.statistics.miss;
-                calcOptions.greats = this.statistics.great;
-            }
-            calcOptions.accuracy =
-                currentBeatmap.calculateAccuracy(calcOptions);
-
             const maxAchievablePerformance =
                 currentBeatmap.calculatePerformance(
                     beatmapPP.difficultyAttributes,
-                    calcOptions
+                    calculateMaxAchievableScore(
+                        currentBeatmap,
+                        this.combo,
+                        scoreInfo,
+                        currDiff,
+                        beatmapPP.maxScore
+                    )
                 );
+
             beatmapPP.currAttributes.maxAchievable =
                 maxAchievablePerformance.pp;
 
-            calcOptions.maxCombo = beatmapPP.maxScore.maxCombo;
-            if (this.mode === 3) {
-                calcOptions.perfects +=
-                    calcOptions.misses + calcOptions.comboBreaks;
-            } else {
-                calcOptions.greats +=
-                    calcOptions.misses + calcOptions.comboBreaks;
-            }
-            calcOptions.largeTickHits += calcOptions.largeTickMisses;
-            calcOptions.largeTickMisses = 0;
-            calcOptions.sliderEndHits = beatmapPP.maxScore.sliderEndHits;
-            calcOptions.comboBreaks = 0;
-            calcOptions.misses = 0;
-            calcOptions.accuracy =
-                currentBeatmap.calculateAccuracy(calcOptions);
-
             const fcPerformance = currentBeatmap.calculatePerformance(
                 beatmapPP.difficultyAttributes,
-                calcOptions
+                calculateFcScore(
+                    currentBeatmap,
+                    scoreInfo,
+                    currDiff,
+                    beatmapPP.maxScore
+                )
             );
             beatmapPP.currAttributes.fcPP = fcPerformance.pp;
             beatmapPP.updatePPAttributes('fc', fcPerformance);

--- a/packages/tosu/src/states/gameplay.ts
+++ b/packages/tosu/src/states/gameplay.ts
@@ -563,7 +563,8 @@ export class Gameplay extends AbstractState {
                         this.combo,
                         scoreInfo,
                         currDiff,
-                        beatmapPP.maxScore
+                        beatmapPP.maxScore,
+                        beatmapPP.difficultyAttributes.getData()
                     )
                 );
 

--- a/packages/tosu/src/states/resultScreen.ts
+++ b/packages/tosu/src/states/resultScreen.ts
@@ -6,6 +6,7 @@ import { AbstractState } from '@/states';
 import { calculateGrade } from '@/utils/calculators';
 import { defaultCalculatedMods } from '@/utils/osuMods';
 import type { CalculateMods } from '@/utils/osuMods.types';
+import { calculateFcScore } from '@/utils/score';
 
 import { defaultStatistics } from './gameplay';
 import type { Statistics } from './types';
@@ -127,7 +128,7 @@ export class ResultScreen extends AbstractState {
 
             const currentBeatmap = beatmapPP.getCurrentBeatmap();
             const diffAttrs = beatmapPP.difficultyAttributes;
-            if (!currentBeatmap || !diffAttrs) {
+            if (!currentBeatmap || !diffAttrs || !beatmapPP.maxScore) {
                 wLogger.debug(
                     `%${ClientType[this.game.client]}%`,
                     `Result screen PP calc skipped: Can't get current map`
@@ -167,30 +168,15 @@ export class ResultScreen extends AbstractState {
                 calcOptions
             );
 
-            const fcCalcOptions: ScoreInfoData = {
-                ...calcOptions,
-                greats: this.statistics.great + this.statistics.miss,
-                misses: 0,
-                maxCombo: beatmapPP.calculatedMapAttributes.maxCombo
-            };
-            if (this.mode === 3) {
-                fcCalcOptions.perfects =
-                    this.statistics.perfect +
-                    this.statistics.ok +
-                    this.statistics.meh +
-                    this.statistics.miss;
-                fcCalcOptions.greats = this.statistics.great;
-                fcCalcOptions.goods = this.statistics.good;
-                fcCalcOptions.oks = 0;
-                fcCalcOptions.mehs = 0;
-                fcCalcOptions.misses = 0;
-                fcCalcOptions.accuracy = this.accuracy / 100;
-            }
-
             const t2 = performance.now();
             const fcPerformance = currentBeatmap.calculatePerformance(
                 diffAttrs,
-                fcCalcOptions
+                calculateFcScore(
+                    currentBeatmap,
+                    calcOptions,
+                    diffAttrs.getData(),
+                    beatmapPP.maxScore
+                )
             );
 
             this.pp = curPerformance.pp;

--- a/packages/tosu/src/utils/score.ts
+++ b/packages/tosu/src/utils/score.ts
@@ -11,18 +11,42 @@ import type {
  * @param current Current score data.
  * @param curDiff Current difficulty attributes.
  * @param max Maximum possible score.
+ * @param beatmapDiff Current beatmap difficulty attributes.
  */
 export function calculateMaxAchievableScore(
     beatmap: PlayBeatmap,
     combo: number,
     current: ScoreInfoData,
     curDiff: DifficultyAttrsData,
-    max: ScoreInfoData
+    max: ScoreInfoData,
+    beatmapDiff: DifficultyAttrsData
 ): ScoreInfoData {
     const score = populateMaxHits(beatmap.mode, current, curDiff, max);
     // Calculate max achievable combo using current max combo or current combo plus remaining combo
     const remainingCombo = max.maxCombo - curDiff.maxCombo;
     score.maxCombo = Math.max(score.maxCombo, combo + remainingCombo);
+
+    // If the current score is a legacy score and std, calculate the max achievable score.
+    // This is required because std pp calculation uses legacy score values for miss estimation.
+    // See https://osu.ppy.sh/wiki/en/Gameplay/Score/ScoreV1/osu%21 for formula reference.
+    // REMOVE: When there are proper way to calculate total score.
+    if (current.isLegacyScore && beatmap.mode === 0) {
+        // Combo multiplier sum base in remaining section.
+        const comboMultiplierBase =
+            Math.max(curDiff.maxCombo - 1, 0) +
+            Math.max(max.maxCombo - 1, 0) -
+            1;
+
+        // Adjusted combo multiplier sum base in remaining section adding current combo.
+        const adjustedComboMultiplierBase =
+            Math.max(combo - 1, 0) * 2 + remainingCombo - 1;
+
+        const remainingScore =
+            (approxStdMaxScore(beatmapDiff) - approxStdMaxScore(curDiff)) *
+            (adjustedComboMultiplierBase / comboMultiplierBase);
+
+        score.totalScore += remainingScore;
+    }
 
     score.accuracy = beatmap.calculateAccuracy(score);
     return score;
@@ -123,4 +147,18 @@ function getMaxHit(mode: number, score: ScoreInfoData) {
         default:
             return score.greats;
     }
+}
+
+/**
+ * Approximate the total score for osu! based on combo score and hit objects.
+ * The returned score doesn't include any bonus scores.
+ * But they are not meaningful in pp calculation.
+ *
+ * REMOVE: When there are proper way to calculate total score.
+ */
+function approxStdMaxScore(diff: DifficultyAttrsData): number {
+    return (
+        diff.maximumLegacyComboScore +
+        (diff.nCircles + diff.nSliders + diff.nSpinners) * 300
+    );
 }

--- a/packages/tosu/src/utils/score.ts
+++ b/packages/tosu/src/utils/score.ts
@@ -1,0 +1,126 @@
+import type {
+    DifficultyAttrsData,
+    PlayBeatmap,
+    ScoreInfoData
+} from '@tosuapp/lazer-calculator-prebuilt';
+
+/**
+ * Calculate the maximum achievable score based on current score.
+ * @param beatmap Current beatmap.
+ * @param combo Current combo count.
+ * @param current Current score data.
+ * @param curDiff Current difficulty attributes.
+ * @param max Maximum possible score.
+ */
+export function calculateMaxAchievableScore(
+    beatmap: PlayBeatmap,
+    combo: number,
+    current: ScoreInfoData,
+    curDiff: DifficultyAttrsData,
+    max: ScoreInfoData
+): ScoreInfoData {
+    const score = populateMaxHits(beatmap.mode, current, curDiff, max);
+    // Calculate max achievable combo using current max combo or current combo plus remaining combo
+    const remainingCombo = max.maxCombo - curDiff.maxCombo;
+    score.maxCombo = Math.max(score.maxCombo, combo + remainingCombo);
+
+    score.accuracy = beatmap.calculateAccuracy(score);
+    return score;
+}
+
+/**
+ * Calculate a full combo score based on current score.
+ * @param beatmap Current beatmap.
+ * @param current Current score data.
+ * @param curDiff Current difficulty attributes.
+ * @param max Maximum possible score.
+ */
+export function calculateFcScore(
+    beatmap: PlayBeatmap,
+    current: ScoreInfoData,
+    curDiff: DifficultyAttrsData,
+    max: ScoreInfoData
+): ScoreInfoData {
+    const score = populateMaxHits(beatmap.mode, current, curDiff, max);
+    score.maxCombo = max.maxCombo;
+
+    // Remove misses and replace to max hit.
+    setMaxHit(
+        beatmap.mode,
+        score,
+        getMaxHit(beatmap.mode, score) + current.misses + current.comboBreaks
+    );
+    score.comboBreaks = 0;
+    score.misses = 0;
+
+    // Full combo scores doesn't have large tick and slider end misses.
+    score.largeTickHits = max.largeTickHits;
+    score.largeTickMisses = 0;
+    score.sliderEndHits = max.sliderEndHits;
+
+    score.accuracy = beatmap.calculateAccuracy(score);
+    return score;
+}
+
+/**
+ * Populate the remaining maximum hit results for the current beatmap
+ * @param mode Current game mode.
+ * @param current Current score data.
+ * @param curDiff Current difficulty attributes.
+ * @param max Maximum possible score.
+ */
+function populateMaxHits(
+    mode: number,
+    current: ScoreInfoData,
+    curDiff: DifficultyAttrsData,
+    max: ScoreInfoData
+): ScoreInfoData {
+    const score = {
+        ...current,
+        largeTickHits: max.largeTickHits - current.largeTickMisses,
+
+        // Calculate max archivable slider end hits based on difference between max and current hits
+        sliderEndHits:
+            max.sliderEndHits - (curDiff.nSliders - current.sliderEndHits),
+
+        // Small hit ticks doesn't affect combo but only accuracy.
+        smallTickHits: max.smallTickHits - current.smallTickMisses
+    };
+    setMaxHit(
+        mode,
+        score,
+        getMaxHit(mode, max) -
+            current.goods -
+            current.oks -
+            current.mehs -
+            current.misses
+    );
+
+    return score;
+}
+
+function setMaxHit(mode: number, score: ScoreInfoData, count: number) {
+    switch (mode) {
+        // osu!mania
+        case 3:
+            score.perfects = count;
+            break;
+
+        // osu!standard, osu!taiko, osu!catch
+        default:
+            score.greats = count;
+            break;
+    }
+}
+
+function getMaxHit(mode: number, score: ScoreInfoData) {
+    switch (mode) {
+        // osu!mania
+        case 3:
+            return score.perfects;
+
+        // osu!standard, osu!taiko, osu!catch
+        default:
+            return score.greats;
+    }
+}

--- a/packages/tosu/src/utils/score.ts
+++ b/packages/tosu/src/utils/score.ts
@@ -152,7 +152,6 @@ function getMaxHit(mode: number, score: ScoreInfoData) {
 /**
  * Approximate the total score for osu! based on combo score and hit objects.
  * The returned score doesn't include any bonus scores.
- * But they are not meaningful in pp calculation.
  *
  * REMOVE: When there are proper way to calculate total score.
  */

--- a/packages/tosu/src/utils/score.ts
+++ b/packages/tosu/src/utils/score.ts
@@ -41,11 +41,14 @@ export function calculateMaxAchievableScore(
         const adjustedComboMultiplierBase =
             Math.max(combo - 1, 0) * 2 + remainingCombo - 1;
 
-        const remainingScore =
-            (approxStdMaxScore(beatmapDiff) - approxStdMaxScore(curDiff)) *
+        const remainingAccScore =
+            stdMaxAccScore(beatmapDiff) - stdMaxAccScore(curDiff);
+        const remainingComboScore =
+            (beatmapDiff.maximumLegacyComboScore -
+                curDiff.maximumLegacyComboScore) *
             (adjustedComboMultiplierBase / comboMultiplierBase);
 
-        score.totalScore += remainingScore;
+        score.totalScore += remainingAccScore + remainingComboScore;
     }
 
     score.accuracy = beatmap.calculateAccuracy(score);
@@ -150,14 +153,11 @@ function getMaxHit(mode: number, score: ScoreInfoData) {
 }
 
 /**
- * Approximate the total score for osu! based on combo score and hit objects.
- * The returned score doesn't include any bonus scores.
+ * Approximate the total accuracy score for osu! based on hit objects.
+ * The returned accuracy score doesn't include any bonus scores.
  *
  * REMOVE: When there are proper way to calculate total score.
  */
-function approxStdMaxScore(diff: DifficultyAttrsData): number {
-    return (
-        diff.maximumLegacyComboScore +
-        (diff.nCircles + diff.nSliders + diff.nSpinners) * 300
-    );
+function stdMaxAccScore(diff: DifficultyAttrsData): number {
+    return (diff.nCircles + diff.nSliders + diff.nSpinners) * 300;
 }

--- a/packages/tosu/src/utils/score.ts
+++ b/packages/tosu/src/utils/score.ts
@@ -159,5 +159,8 @@ function getMaxHit(mode: number, score: ScoreInfoData) {
  * REMOVE: When there are proper way to calculate total score.
  */
 function stdMaxAccScore(diff: DifficultyAttrsData): number {
-    return (diff.nCircles + diff.nSliders + diff.nSpinners) * 300;
+    return (
+        (diff.nCircles + diff.nSliders + diff.nSpinners) *
+        (300 + diff.nestedScorePerObject)
+    );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,8 +168,8 @@ importers:
         specifier: workspace:*
         version: link:../updater
       '@tosuapp/lazer-calculator-prebuilt':
-        specifier: 0.5.0-20260715-main.0
-        version: 0.5.0-20260715-main.0
+        specifier: 0.5.1-20260718-main.0
+        version: 0.5.1-20260718-main.0
       osu-catch-stable:
         specifier: ^4.0.1
         version: 4.0.1(osu-classes@3.1.0)
@@ -1498,18 +1498,18 @@ packages:
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
 
-  '@tosuapp/lazer-calculator-linux-x64@0.5.0-20260715-main.0':
-    resolution: {integrity: sha512-Kijl0kbi9JHLMGglbFS1UjlVGyxKK95H9R+Qu5B4Y+K7hVR2V5/F0/sMl+1+kN6XXAbwjZQLgZh1vsjwdS9WoQ==}
+  '@tosuapp/lazer-calculator-linux-x64@0.5.1-20260718-main.0':
+    resolution: {integrity: sha512-suEJgYafJktp4GB2N0ar4I9LEZYjDjqnGa0ad3ILurn8Gm6o5F+nmc0uE/Po4ej9Oxv4aUOwsZxMBZmJq8qucg==}
     cpu: [x64]
     os: [linux]
 
-  '@tosuapp/lazer-calculator-prebuilt@0.5.0-20260715-main.0':
-    resolution: {integrity: sha512-9lFZSolJiyxHyCA3a3DlGqMlI51D5eUwWjwbBPcy23Cc9hvEQ0yOxzhQguKh4zq5ndwIOiq0hFbZO2ruFCcyFA==}
+  '@tosuapp/lazer-calculator-prebuilt@0.5.1-20260718-main.0':
+    resolution: {integrity: sha512-7Z8Y2H9pZWqxh+DD4Y60UWlY6JzXLf5eefHZZqD+gB5ozv1ITnkitEuPRp96JXki6nOWICMAZOUAbzj6qWT2bw==}
     cpu: [x64]
     os: [win32, linux]
 
-  '@tosuapp/lazer-calculator-win32-x64@0.5.0-20260715-main.0':
-    resolution: {integrity: sha512-an1DnYpM6zdOdvXu3XQkoDfbgWGpitGo5dPohJQmEHYk8P4G+2eXLDnJS2E4TDQS06E/jhnRFl45J+XZhMXQ9Q==}
+  '@tosuapp/lazer-calculator-win32-x64@0.5.1-20260718-main.0':
+    resolution: {integrity: sha512-3e+rZ9ajYg9HBnhfvQuPc6vloUlmA4zYfeJvH9O+VBEaWnCkpeXTERTEjFFNH9rDoVqQ1yFH4y2Q8UkmZPNQyw==}
     cpu: [x64]
     os: [win32]
 
@@ -5801,15 +5801,15 @@ snapshots:
 
   '@tootallnate/once@2.0.1': {}
 
-  '@tosuapp/lazer-calculator-linux-x64@0.5.0-20260715-main.0':
+  '@tosuapp/lazer-calculator-linux-x64@0.5.1-20260718-main.0':
     optional: true
 
-  '@tosuapp/lazer-calculator-prebuilt@0.5.0-20260715-main.0':
+  '@tosuapp/lazer-calculator-prebuilt@0.5.1-20260718-main.0':
     optionalDependencies:
-      '@tosuapp/lazer-calculator-linux-x64': 0.5.0-20260715-main.0
-      '@tosuapp/lazer-calculator-win32-x64': 0.5.0-20260715-main.0
+      '@tosuapp/lazer-calculator-linux-x64': 0.5.1-20260718-main.0
+      '@tosuapp/lazer-calculator-win32-x64': 0.5.1-20260718-main.0
 
-  '@tosuapp/lazer-calculator-win32-x64@0.5.0-20260715-main.0':
+  '@tosuapp/lazer-calculator-win32-x64@0.5.1-20260718-main.0':
     optional: true
 
   '@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.7.4)':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,8 +168,8 @@ importers:
         specifier: workspace:*
         version: link:../updater
       '@tosuapp/lazer-calculator-prebuilt':
-        specifier: 0.5.1-20260718-main.0
-        version: 0.5.1-20260718-main.0
+        specifier: 0.6.0-20260726-main.0
+        version: 0.6.0-20260726-main.0
       osu-catch-stable:
         specifier: ^4.0.1
         version: 4.0.1(osu-classes@3.1.0)
@@ -1498,18 +1498,18 @@ packages:
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
     engines: {node: '>= 10'}
 
-  '@tosuapp/lazer-calculator-linux-x64@0.5.1-20260718-main.0':
-    resolution: {integrity: sha512-suEJgYafJktp4GB2N0ar4I9LEZYjDjqnGa0ad3ILurn8Gm6o5F+nmc0uE/Po4ej9Oxv4aUOwsZxMBZmJq8qucg==}
+  '@tosuapp/lazer-calculator-linux-x64@0.6.0-20260726-main.0':
+    resolution: {integrity: sha512-X/y74HMwjtHbEbWCbSv9Ln7yHtbbJtci2ZrPIaPIVrQR8jTI7LQGtSP+xfCZlOZla+/bu4u0k+LRmUxYkjCfyg==}
     cpu: [x64]
     os: [linux]
 
-  '@tosuapp/lazer-calculator-prebuilt@0.5.1-20260718-main.0':
-    resolution: {integrity: sha512-7Z8Y2H9pZWqxh+DD4Y60UWlY6JzXLf5eefHZZqD+gB5ozv1ITnkitEuPRp96JXki6nOWICMAZOUAbzj6qWT2bw==}
+  '@tosuapp/lazer-calculator-prebuilt@0.6.0-20260726-main.0':
+    resolution: {integrity: sha512-5OaB/KPx+LlPj7YuKPV/vELdSDr68TcAvWmBdGWv5lSWC8BZUibAta83kbOYNf3szm7hbSfA3RTo9j5kTYcrcQ==}
     cpu: [x64]
     os: [win32, linux]
 
-  '@tosuapp/lazer-calculator-win32-x64@0.5.1-20260718-main.0':
-    resolution: {integrity: sha512-3e+rZ9ajYg9HBnhfvQuPc6vloUlmA4zYfeJvH9O+VBEaWnCkpeXTERTEjFFNH9rDoVqQ1yFH4y2Q8UkmZPNQyw==}
+  '@tosuapp/lazer-calculator-win32-x64@0.6.0-20260726-main.0':
+    resolution: {integrity: sha512-d68yAxJUF4FgNpWBZQ9E/ImsucWnwKKt5IJHftvYsUvDbSju2wdyYAsHSGWdl6IXINOWLQPK4x97YArIBS69Ig==}
     cpu: [x64]
     os: [win32]
 
@@ -5801,15 +5801,15 @@ snapshots:
 
   '@tootallnate/once@2.0.1': {}
 
-  '@tosuapp/lazer-calculator-linux-x64@0.5.1-20260718-main.0':
+  '@tosuapp/lazer-calculator-linux-x64@0.6.0-20260726-main.0':
     optional: true
 
-  '@tosuapp/lazer-calculator-prebuilt@0.5.1-20260718-main.0':
+  '@tosuapp/lazer-calculator-prebuilt@0.6.0-20260726-main.0':
     optionalDependencies:
-      '@tosuapp/lazer-calculator-linux-x64': 0.5.1-20260718-main.0
-      '@tosuapp/lazer-calculator-win32-x64': 0.5.1-20260718-main.0
+      '@tosuapp/lazer-calculator-linux-x64': 0.6.0-20260726-main.0
+      '@tosuapp/lazer-calculator-win32-x64': 0.6.0-20260726-main.0
 
-  '@tosuapp/lazer-calculator-win32-x64@0.5.1-20260718-main.0':
+  '@tosuapp/lazer-calculator-win32-x64@0.6.0-20260726-main.0':
     optional: true
 
   '@trivago/prettier-plugin-sort-imports@5.2.2(prettier@3.7.4)':


### PR DESCRIPTION
## Changes
* Bump lazer calc.
* Simulate maximum achievable total score for stable std pp calculation.

## Todo
* [x] Move full combo score calculation logic into separated file.
* [x] Move maximum achievable score calculation logic into separated file.
* [x] Implement maximum achievable `totalScore` calculation to account score based miss estimation in std pp calculation. Due to absence of this, maximum achievable pp was sometimes being smaller than current pp in midplay.

| before | after |
| --- | --- |
| <img width="382" height="276" alt="image" src="https://github.com/user-attachments/assets/b6834b7c-0322-460b-9b46-eebd62cab3ed" /> | <img width="389" height="283" alt="image" src="https://github.com/user-attachments/assets/adea695a-ce3b-43f5-82e7-06aea9bd698e" /> |