### PR TITLE
feat: ingame overlay interact button

### DIFF
--- a/packages/ingame-overlay/renderer/index.html
+++ b/packages/ingame-overlay/renderer/index.html
@@ -103,6 +103,10 @@
                     settings
                     <i class="icon-link"></i>
                 </a>
+                <a class="ctx-button" :href="profile.overlays[context_overlay.index].url" target="_blank">
+                    interact
+                    <i class="icon-link"></i>
+                </a>
                 <div class="ctx-button" @click.left="reset_overlay(context_overlay.index)">
                     reset
                 </div>

--- a/packages/ingame-overlay/src/index.ts
+++ b/packages/ingame-overlay/src/index.ts
@@ -14,6 +14,11 @@ app.commandLine.appendSwitch('force-device-scale-factor', '1');
 // run in process gpu, reduce overheads
 app.commandLine.appendSwitch('in-process-gpu');
 app.commandLine.appendSwitch('disable-direct-composition');
+// disable third party storage partitioning, to avoid issues with overlays using isolated storage
+app.commandLine.appendSwitch(
+    'disable-features',
+    'ThirdPartyStoragePartitioning'
+);
 
 (async () => {
     // Dev mode


### PR DESCRIPTION
Add interact button to open new interactive window(like obs).

Some overlays embedded settings in page and couldn't adjust settings for ingame overlay.

<img width="449" height="301" alt="image" src="https://github.com/user-attachments/assets/5165e1b6-4bcd-4d76-90a3-2620540382b7" />
