### PR TITLE
feat: Add option to temporarily skip CI.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,13 @@ permissions:
 
 jobs:
   build:
+    if: |
+      github.event_name != 'pull_request' || (
+        !contains(github.event.pull_request.labels.*.name, 'skip ci') &&
+        !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+        !contains(github.event.pull_request.title, '[skip ci]') &&
+        !contains(github.event.pull_request.body, '[skip ci]')
+      )
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-latest ]

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -9,6 +9,11 @@ concurrency:
 
 jobs:
   lint:
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'skip ci') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+      !contains(github.event.pull_request.title, '[skip ci]') &&
+      !contains(github.event.pull_request.body, '[skip ci]')
     runs-on: ubuntu-latest
     #runs-on: windows-latest
     steps:


### PR DESCRIPTION
Useful for Draft PRs that are not made to compile yet.
Reduces github actions usage. Uses the Github official `[skip ci]` tag or the label `Skip CI`.