### PR TITLE
docs: update Node.js requirement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <a href="https://github.com/tosuapp/tosu/blob/master/LICENSE" target="_blank"><img alt="License: GPL--3.0" src="https://img.shields.io/github/license/tosuapp/tosu?style=for-the-badge&color=%23A27456" /></a>
   <img alt="Version" src="https://img.shields.io/github/release/tosuapp/tosu.svg?style=for-the-badge&color=%235686A2" />
-  <img src="https://img.shields.io/badge/node-%3E%3D20.11.1-45915E.svg?style=for-the-badge&logo=node.js&logoColor=white" />
+  <img src="https://img.shields.io/badge/node-%3E%3D24.14.0-45915E.svg?style=for-the-badge&logo=node.js&logoColor=white" />
   <a href="https://twitter.com/kotrik0" target="_blank"><img alt="Twitter: kotrik0" src="https://img.shields.io/badge/kotrik0-5593ba?style=for-the-badge&logo=x&logoColor=white" /></a>
 </p>
 


### PR DESCRIPTION
README.md list Node.js 20.11.1 but package.jsonn requires >=24.14.0

Updated the README node.js badge to match the version