### PR TITLE
fix: unsafe printf usage

### DIFF
--- a/packages/tsprocess/lib/functions.cc
+++ b/packages/tsprocess/lib/functions.cc
@@ -32,7 +32,7 @@ Napi::Value read_byte(const Napi::CallbackInfo &args) {
 
   auto result = memory::read<int8_t>(handle, address);
   if (!std::get<1>(result)) {
-    Napi::TypeError::New(env, logger::format("Couldn't read byte at %x", address)).ThrowAsJavaScriptException();
+    Napi::TypeError::New(env, std::format("Couldn't read byte at {:x}", address)).ThrowAsJavaScriptException();
     return env.Null();
   }
   return Napi::Number::New(env, std::get<0>(result));
@@ -50,7 +50,7 @@ Napi::Value read_short(const Napi::CallbackInfo &args) {
 
   auto result = memory::read<int16_t>(handle, address);
   if (!std::get<1>(result)) {
-    Napi::TypeError::New(env, logger::format("Couldn't read short at %x", address)).ThrowAsJavaScriptException();
+    Napi::TypeError::New(env, std::format("Couldn't read short at {:x}", address)).ThrowAsJavaScriptException();
     return env.Null();
   }
   return Napi::Number::New(env, std::get<0>(result));
@@ -68,7 +68,7 @@ Napi::Value read_int(const Napi::CallbackInfo &args) {
 
   auto result = memory::read<int32_t>(handle, address);
   if (!std::get<1>(result)) {
-    Napi::TypeError::New(env, logger::format("Couldn't read int at %x", address)).ThrowAsJavaScriptException();
+    Napi::TypeError::New(env, std::format("Couldn't read int at {:x}", address)).ThrowAsJavaScriptException();
     return env.Null();
   }
   return Napi::Number::New(env, std::get<0>(result));
@@ -86,7 +86,7 @@ Napi::Value read_uint(const Napi::CallbackInfo &args) {
 
   auto result = memory::read<uint32_t>(handle, address);
   if (!std::get<1>(result)) {
-    Napi::TypeError::New(env, logger::format("Couldn't read uint at %x", address)).ThrowAsJavaScriptException();
+    Napi::TypeError::New(env, std::format("Couldn't read uint at {:x}", address)).ThrowAsJavaScriptException();
     return env.Null();
   }
   return Napi::Number::New(env, std::get<0>(result));
@@ -104,7 +104,7 @@ Napi::Value read_float(const Napi::CallbackInfo &args) {
 
   auto result = memory::read<float>(handle, address);
   if (!std::get<1>(result)) {
-    Napi::TypeError::New(env, logger::format("Couldn't read float at %x", address)).ThrowAsJavaScriptException();
+    Napi::TypeError::New(env, std::format("Couldn't read float at {:x}", address)).ThrowAsJavaScriptException();
     return env.Null();
   }
   return Napi::Number::New(env, std::get<0>(result));
@@ -122,7 +122,7 @@ Napi::Value read_long(const Napi::CallbackInfo &args) {
 
   auto result = memory::read<int64_t>(handle, address);
   if (!std::get<1>(result)) {
-    Napi::TypeError::New(env, logger::format("Couldn't read long at %x", address)).ThrowAsJavaScriptException();
+    Napi::TypeError::New(env, std::format("Couldn't read long at {:x}", address)).ThrowAsJavaScriptException();
     return env.Null();
   }
   return Napi::Number::New(env, std::get<0>(result));
@@ -141,7 +141,7 @@ Napi::Value read_double(const Napi::CallbackInfo &args) {
 
   auto result = memory::read<double>(handle, address);
   if (!std::get<1>(result)) {
-    Napi::TypeError::New(env, logger::format("Couldn't read double at %x", address)).ThrowAsJavaScriptException();
+    Napi::TypeError::New(env, std::format("Couldn't read double at {:x}", address)).ThrowAsJavaScriptException();
     return env.Null();
   }
   return Napi::Number::New(env, std::get<0>(result));
@@ -236,7 +236,7 @@ Napi::Value read_buffer(const Napi::CallbackInfo &args) {
   if (!result) {
     free(data);
     delete[] buffer;
-    Napi::TypeError::New(env, logger::format("Couldn't read buffer at %x", address)).ThrowAsJavaScriptException();
+    Napi::TypeError::New(env, std::format("Couldn't read buffer at {:x}", address)).ThrowAsJavaScriptException();
 
     return env.Null();
   }
@@ -453,11 +453,11 @@ Napi::Value read_csharp_string(const Napi::CallbackInfo &args) {
   auto [string_length, length_success] = memory::read<int>(handle, address + offset);
   if (!length_success) {
 #ifdef _WIN32
-    auto error_str = logger::format(
-      "Couldn't read C# string length (base: %x, length: %x, last error: %d)", address, address + sizeof(int), GetLastError()
+    auto error_str = std::format(
+      "Couldn't read C# string length (base: {:x}, length: {:x}, last error: {})", address, address + sizeof(int), GetLastError()
     );
 #else
-    auto error_str = logger::format("Couldn't read C# string length (base: %x)", address);
+    auto error_str = std::format("Couldn't read C# string length (base: {:x})", address);
 #endif
     Napi::TypeError::New(env, error_str.c_str()).ThrowAsJavaScriptException();
     return env.Null();

--- a/packages/tsprocess/lib/logger.h
+++ b/packages/tsprocess/lib/logger.h
@@ -1,23 +1,12 @@
-#include <memory>
+#include <cstdio>
+#include <format>
 #include <string>
 
 namespace logger {
 
 template <typename... Args>
-std::string format(const std::string_view format, Args... args) {
-  const auto size = std::snprintf(nullptr, 0, format.data(), args...) + 1;
-  if (size <= 0) {
-    return {};
-  }
-  auto buffer = std::make_unique<char[]>(size);
-  std::snprintf(buffer.get(), size, format.data(), args...);
-  return std::string(buffer.get(), size - 1);
-}
-
-template <typename... Args>
-void println(const std::string_view format, Args... args) {
-  std::printf(logger::format(format, args...).c_str());
-  std::printf("\n");
+void println(std::format_string<Args...> format, Args &&...args) {
+  std::printf("%s\n", std::format(format, std::forward<Args>(args)...).c_str());
 }
 
 }  // namespace logger

--- a/packages/tsprocess/lib/memory/memory_linux.cc
+++ b/packages/tsprocess/lib/memory/memory_linux.cc
@@ -157,7 +157,7 @@ bool memory::read_buffer(void *process, uintptr_t address, std::size_t size, uin
   const auto success = result_size == size;
 
   if (!success && errno == EPERM) {
-    logger::println("failed to read address %x of size %x", address, size);
+    logger::println("failed to read address {:x} of size {:x}", address, size);
     logger::println("Consider running with sudo or using setcap:");
     logger::println("  sudo /path/to/tosu");
     logger::println("  sudo setcap cap_sys_ptrace=eip /path/to/tosu");


### PR DESCRIPTION
Previously, a string was passed to `snprintf` (in `logger::format`), and then to `printf` (in `logger::println`). If `logger::format` returned a string with `%` chars, this would have lead to a [printf exploit](https://en.wikipedia.org/wiki/Uncontrolled_format_string). In practice, user-controlled strings were never passed to `logger::println`, but it's still a good practice to fix this.

Additionally, since the project uses C++20, I switched the use of `snprintf` to `std::format`. This saves on some allocations, makes the code simpler, and ensures there will be no more printf exploits in the codebase. I still had to keep `logger::println`, as `std::println` was only added in C++23.

Before this PR, the code didn't compile at all on my machine, as gcc (quite correctly) rejected the code as unsafe.

In general, when writing wrappers for `printf`/`snprintf`, it's best to use the relevant compiler safety features (such as `__attribute__((format(printf, a, b)))` and `_Printf_format_string_`), and use `const char*` rather than `string_view` for the format string (there's no reason to use anything other than `const char*` when the string is statically known, which it should be, and the compiler safety features generally expect `const char*`).