### PR TITLE
fix(stable): allow falsy config and keybind values in settings

### DIFF
--- a/packages/tosu/src/memory/stable.ts
+++ b/packages/tosu/src/memory/stable.ts
@@ -1381,7 +1381,12 @@ export class StableMemory extends AbstractMemory<OsuPatternData> {
                 try {
                     const result = this.configValue(configPointer, position);
                     if (result instanceof Error) throw result;
-                    if (result === null || !result.key || !result.value)
+                    if (
+                        result === null ||
+                        !result.key ||
+                        result.value === undefined ||
+                        result.value === null
+                    )
                         continue;
 
                     const value = configList[result.key];
@@ -1414,7 +1419,12 @@ export class StableMemory extends AbstractMemory<OsuPatternData> {
                 try {
                     const result = this.bindingValue(bindingPointer, position);
                     if (result instanceof Error) throw result;
-                    if (!result.key || !result.value) continue;
+                    if (
+                        !result.key ||
+                        result.value === undefined ||
+                        result.value === null
+                    )
+                        continue;
 
                     const value = bindingList[result.key];
                     if (!value || !isAllowedValue(value[0], result.value))


### PR DESCRIPTION
Resolves https://github.com/tosuapp/tosu/issues/707

### Summary of Changes
- Replaced truthiness checks (`!result.value`) in `StableMemory.settings()` with explicit `undefined` and `null` checks (`result.value === undefined || result.value === null`) for both configuration and keybinding value reads.

### Problem Solved
On osu! stable, config values that evaluated to falsy (`false` for booleans, `0` for numbers, `""` for strings, and `0` / `VirtualKeyCode.None` for keybinds) were skipped in `StableMemory.settings()`. Because `Settings.updateState()` only updates keys that are present in the returned dictionary, once a setting held a non-falsy value, it could never update back to `false`, `0`, or `None`.

### Files Affected
- `packages/tosu/src/memory/stable.ts`

### Testing & Verification
- Created an isolated unit test reproducing the issue using mock memory reads for `RawInput: false`, `VolumeUniversal: 0`, `Skin: ""` and unbound keybinding `TaikoInnerLeft: 0` (`VirtualKeyCode.None`).
- Verified that the original logic failed the assertions and the updated logic passed all checks.
- Verified TypeScript compilation via `pnpm run -C packages/tosu ts:compile`.
- Verified formatting and linting via `pnpm run prettier:ci` and `pnpm run lint:ci`.

***

Fixed by Gemini 3.8 Flash