### PR TITLE
Lazer leaderboard part fix

### DIFF
--- a/packages/tosu/src/memory/lazer.ts
+++ b/packages/tosu/src/memory/lazer.ts
@@ -162,6 +162,21 @@ export interface Offsets {
     'osu.Game.Screens.OnlinePlay.Multiplayer.Multiplayer': {
         '<client>k__BackingField': number;
     };
+    'osu.Game.Screens.OnlinePlay.Multiplayer.MultiplayerPlayer': {
+        '<client>k__BackingField': number;
+        leaderboardProvider: number;
+    };
+    'osu.Game.Screens.Play.Leaderboards.MultiplayerLeaderboardProvider': {
+        UserScores: number;
+    };
+    'osu.Game.Screens.Play.Leaderboards.MultiplayerLeaderboardProvider.TrackedUserData': {
+        User: number;
+        ScoreProcessor: number;
+    };
+    'osu.Game.Online.Spectator.SpectatorScoreProcessor': {
+        scoreInfo: number;
+        Combo: number;
+    };
     'osu.Game.Online.Multiplayer.MultiplayerRoom': {
         RoomID: number;
         '<ChannelID>k__BackingField': number;
@@ -660,6 +675,17 @@ export class LazerMemory extends AbstractMemory<LazerPatternData> {
                             '<ScoreManager>k__BackingField'
                         ]
                 )
+        );
+    }
+
+    private checkIfMultiplayerPlayer(address: number) {
+        return (
+            this.process.readIntPtr(
+                address +
+                    this.offsets[
+                        'osu.Game.Screens.OnlinePlay.Multiplayer.MultiplayerPlayer'
+                    ]['<client>k__BackingField']
+            ) === this.multiplayerClient()
         );
     }
 
@@ -3462,22 +3488,97 @@ export class LazerMemory extends AbstractMemory<LazerPatternData> {
             -1
         );
 
-        // TODO: update once I bother todo it :)
-        // const leaderboardScores = this.process.readIntPtr(
-        //     player + (this.replayMode ? 0x4e8 : 0x520)
-        // );
+        const leads: LeaderboardPlayer[] = [];
 
-        // const items = this.readListItems(
-        //     this.process.readIntPtr(leaderboardScores + 0x18)
-        // );
+        if (this.checkIfMultiplayerPlayer(player)) {
+            const leaderboard = this.process.readIntPtr(
+                player +
+                    this.offsets[
+                        'osu.Game.Screens.OnlinePlay.Multiplayer.MultiplayerPlayer'
+                    ].leaderboardProvider
+            );
 
-        // const scores: LeaderboardPlayer[] = [];
+            // https://github.com/ppy/osu/blob/master/osu.Game/Screens/Play/Leaderboards/MultiplayerLeaderboardProvider.cs
+            // you can read score info from 2 places
+            // 1. IBindableList<GameplayLeaderboardScore> Scores
+            // 2. Dictionary<int, TrackedUserData> UserScores
+            // first one has less info, including mod data. though second one looks weirder to use.
+            // the second does not have "position" data
 
-        // for (let i = 0; i < items.length; i++) {
-        //     scores.push(this.readLeaderboardScore(items[i], i));
-        // }
+            const userScoresDictionary = this.process.readIntPtr(
+                leaderboard +
+                    this.offsets[
+                        'osu.Game.Screens.Play.Leaderboards.MultiplayerLeaderboardProvider'
+                    ].UserScores
+            );
 
-        return [this.isLeaderboardVisible, personalScore, []];
+            const userScores =
+                this.process.readSharpDictionaryIntToRef(userScoresDictionary);
+
+            // TODO properly set/read position, teamid
+            // teamid is in tracked user data
+            // UserQuit also maybe (i need this actually)
+
+            for (const userScore of userScores) {
+                const scoreProcessor = this.process.readIntPtr(
+                    userScore.address +
+                        this.offsets[
+                            'osu.Game.Screens.Play.Leaderboards.MultiplayerLeaderboardProvider.TrackedUserData'
+                        ].ScoreProcessor
+                );
+
+                const scoreInfo = this.process.readIntPtr(
+                    scoreProcessor +
+                        this.offsets[
+                            'osu.Game.Online.Spectator.SpectatorScoreProcessor'
+                        ].scoreInfo
+                );
+
+                if (!scoreInfo) continue;
+
+                const comboBind = this.process.readIntPtr(
+                    scoreProcessor +
+                        this.offsets[
+                            'osu.Game.Online.Spectator.SpectatorScoreProcessor'
+                        ].Combo
+                );
+
+                const combo = this.process.readBindableInt(comboBind);
+
+                // i think its better to explicitly show we dont know position
+                const player = this.readLeaderboardScore(scoreInfo, 0);
+
+                const user = this.process.readIntPtr(
+                    userScore.address +
+                        this.offsets[
+                            'osu.Game.Screens.Play.Leaderboards.MultiplayerLeaderboardProvider.TrackedUserData'
+                        ].User
+                );
+
+                const apiUser = this.process.readIntPtr(
+                    user +
+                        this.offsets[
+                            'osu.Game.Online.Multiplayer.MultiplayerRoomUser'
+                        ]['<User>k__BackingField']
+                );
+
+                const userName = this.process.readSharpStringPtr(
+                    apiUser +
+                        this.offsets[
+                            'osu.Game.Online.API.Requests.Responses.APIUser'
+                        ]['<Username>k__BackingField']
+                );
+
+                player.userId = userScore.key;
+                player.name = userName;
+                // ScoreInfo does not have current combo :)
+                player.combo = combo;
+
+                leads.push(player);
+            }
+        }
+
+        return [this.isLeaderboardVisible, personalScore, leads];
     }
 
     readSpectatingData(): ILazerSpectator {

--- a/packages/tosu/src/memory/lazer.ts
+++ b/packages/tosu/src/memory/lazer.ts
@@ -413,6 +413,12 @@ export interface Offsets {
         '<RoundsWon>k__BackingField': number;
         '<DamageMultiplier>k__BackingField': number;
     };
+    'osu.Game.Online.Leaderboards.LeaderboardManager': {
+        scores: number;
+    };
+    'osu.Game.Online.Leaderboards.LeaderboardScores': {
+        '<TopScores>k__BackingField': number;
+    };
 }
 
 const localConfigList = [
@@ -3575,6 +3581,49 @@ export class LazerMemory extends AbstractMemory<LazerPatternData> {
                 player.combo = combo;
 
                 leads.push(player);
+            }
+        } else {
+            // there are multiple players, including solo, multiplayer, spectating, playlist
+            // idk it is kinda hard to extract leaderboard from each of them, also each player has its own leaderboard type
+            // the method below works for solo playing, but does not work for spectating.
+
+            // https://github.com/ppy/osu/blob/master/osu.Game/Screens/Play/SoloPlayer.cs
+            // https://github.com/ppy/osu/blob/master/osu.Game/Screens/Play/Leaderboards/SoloGameplayLeaderboardProvider.cs
+            // it is basically 1 additionbal property, and it is hard to be sure it is soloplayer and not something else
+            // and solo leaderboard is basically using leaderboardManager, so its not really that different.
+            const leaderboardManager = this.process.readIntPtr(
+                this.gameBase() +
+                    this.offsets['osu.Game.OsuGameBase'][
+                        '<LeaderboardManager>k__BackingField'
+                    ]
+            );
+
+            const bindableScores = this.process.readIntPtr(
+                leaderboardManager +
+                    this.offsets[
+                        'osu.Game.Online.Leaderboards.LeaderboardManager'
+                    ].scores
+            );
+
+            if (bindableScores) {
+                const leaderboardScores =
+                    this.process.readBindableRef(bindableScores);
+                const scoresArray = this.process.readIntPtr(
+                    leaderboardScores +
+                        this.offsets[
+                            'osu.Game.Online.Leaderboards.LeaderboardScores'
+                        ]['<TopScores>k__BackingField']
+                );
+                const scores = this.process.readSharpRefArray(scoresArray);
+                let index = 0;
+                for (const scoreInfo of scores) {
+                    const player = this.readLeaderboardScore(
+                        scoreInfo,
+                        index++
+                    );
+
+                    leads.push(player);
+                }
             }
         }
 

--- a/packages/tosu/src/memory/lazer.ts
+++ b/packages/tosu/src/memory/lazer.ts
@@ -3604,10 +3604,10 @@ export class LazerMemory extends AbstractMemory<LazerPatternData> {
                         'osu.Game.Online.Leaderboards.LeaderboardManager'
                     ].scores
             );
+            const leaderboardScores =
+                this.process.readBindableRef(bindableScores);
 
-            if (bindableScores) {
-                const leaderboardScores =
-                    this.process.readBindableRef(bindableScores);
+            if (leaderboardScores) {
                 const scoresArray = this.process.readIntPtr(
                     leaderboardScores +
                         this.offsets[

--- a/packages/tsprocess/src/process.ts
+++ b/packages/tsprocess/src/process.ts
@@ -236,6 +236,10 @@ export class Process {
         return result;
     }
 
+    readBindableInt(address: number) {
+        return this.readInt(address + 0x8 + 56);
+    }
+
     readNullableInt(address: number): number | undefined {
         if (this.readByte(address) === 0) {
             return undefined;

--- a/packages/tsprocess/src/process.ts
+++ b/packages/tsprocess/src/process.ts
@@ -240,11 +240,29 @@ export class Process {
         return this.readInt(address + 0x8 + 56);
     }
 
+    readBindableRef(address: number) {
+        return this.readIntPtr(address + 24 + 8);
+    }
+
     readNullableInt(address: number): number | undefined {
         if (this.readByte(address) === 0) {
             return undefined;
         }
         return this.readInt(address + 0x4);
+    }
+
+    readSharpRefArray(address: number): number[] {
+        const result = [];
+
+        const entriesLength = this.readInt(address + 0x8);
+        for (let i = 0; i < entriesLength; i++) {
+            const entrySize = 8;
+            const entry = address + 8 + 0x8 + i * entrySize;
+
+            result.push(this.readIntPtr(entry));
+        }
+
+        return result;
     }
 
     readSharpDictionaryIntToRef(address: number): DictionaryIntToRefEntry[] {


### PR DESCRIPTION
Current implementation has a few things to consider.

It does not work with spectating. Works in solo, viewing replay, multiplayer lobby, ranked play.

When Solo/viewing replay, ILeaderboard.LeaderboardPlayer[] does not contain the data about current play. During multiplayer, it has this data.

In solo scores have weird combo value within their data, but the max combo is correct.

Multiplayer scores do not have all properties set correctly, since its annoying to read their position and team id.

Partially fixes #666
я ребёнок сатаны шесть шесть шесть